### PR TITLE
feat(agent start): renames noBackplane to local ; fixes tmp file coll…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nstrumenta",
-  "version": "1.0.44",
+  "version": "1.0.999",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nstrumenta",
-      "version": "1.0.44",
+      "version": "1.0.999",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^5.16.1",
@@ -19,6 +19,7 @@
         "express": "^4.17.1",
         "form-data": "^4.0.0",
         "inquirer": "^8.1.5",
+        "semver": "^7.3.5",
         "serve-index": "^1.9.1",
         "ws": "^8.2.2"
       },
@@ -30,6 +31,7 @@
         "@types/bytebuffer": "^5.0.42",
         "@types/inquirer": "^8.1.1",
         "@types/node": "^16.7.13",
+        "@types/semver": "^7.3.9",
         "@types/serve-index": "^1.9.1",
         "@types/ws": "^8.2.0",
         "nodemon": "^2.0.12",
@@ -396,6 +398,12 @@
       "version": "1.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -1172,19 +1180,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conf/node_modules/semver": {
-      "version": "7.3.5",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/configstore": {
@@ -3155,6 +3150,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/meow/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/meow/node_modules/type-fest": {
       "version": "0.18.1",
       "dev": true,
@@ -3329,6 +3333,15 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
+    "node_modules/nodemon/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/nopt": {
       "version": "1.0.10",
       "dev": true,
@@ -3349,20 +3362,6 @@
         "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.3.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -3895,6 +3894,15 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "dev": true,
@@ -4060,11 +4068,17 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "dev": true,
-      "license": "ISC",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-diff": {
@@ -4389,20 +4403,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/standard-version/node_modules/semver": {
-      "version": "7.3.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/statuses": {
@@ -5261,6 +5261,12 @@
       "version": "1.2.4",
       "dev": true
     },
+    "@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
+    },
     "@types/serve-index": {
       "version": "1.9.1",
       "dev": true,
@@ -5752,12 +5758,6 @@
           "version": "6.0.1",
           "requires": {
             "is-obj": "^2.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "requires": {
-            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -7021,6 +7021,12 @@
             }
           }
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "type-fest": {
           "version": "0.18.1",
           "dev": true
@@ -7116,6 +7122,14 @@
         "touch": "^3.1.0",
         "undefsafe": "^2.0.3",
         "update-notifier": "^4.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "nopt": {
@@ -7133,15 +7147,6 @@
         "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "normalize-path": {
@@ -7426,6 +7431,12 @@
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -7580,8 +7591,12 @@
       "version": "2.1.2"
     },
     "semver": {
-      "version": "5.7.1",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -7817,13 +7832,6 @@
         "path-exists": {
           "version": "4.0.0",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc --project ./",
-    "dev": "nodemon -- serve",
+    "dev": "nodemon -- agent start",
     "release": "npm run clean; npm run build ; standard-version --release-as patch",
     "nst:local": "LOCAL=true nstrumenta"
   },
@@ -37,6 +37,7 @@
     "@types/bytebuffer": "^5.0.42",
     "@types/inquirer": "^8.1.1",
     "@types/node": "^16.7.13",
+    "@types/semver": "^7.3.9",
     "@types/serve-index": "^1.9.1",
     "@types/ws": "^8.2.0",
     "nodemon": "^2.0.12",
@@ -56,6 +57,7 @@
     "express": "^4.17.1",
     "form-data": "^4.0.0",
     "inquirer": "^8.1.5",
+    "semver": "^7.3.5",
     "serve-index": "^1.9.1",
     "ws": "^8.2.2"
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
+import { Agent } from '../commands/agent';
 import { AddKey, ListProjects, SetProject } from '../commands/auth';
 import {
   AddContext,
@@ -8,13 +9,12 @@ import {
   GetCurrentContext,
   ListContexts,
   SetContext,
-  SetContextProperty,
+  SetContextProperty
 } from '../commands/contexts';
 import { ListMachines } from '../commands/machines';
 import { Publish } from '../commands/publish';
 import { Send, Subscribe } from '../commands/pubsub';
 import { Serve } from '../commands/serve';
-import { Agent } from '../commands/agent';
 import { initContexts } from '../lib/context';
 
 export const DEFAULT_HOST_PORT = '8080';
@@ -87,7 +87,7 @@ agentCommand
   .command('start')
   .option('-n, --name <name>', 'specify module name')
   .option(
-    '-l, --noBackplane',
+    '-l, --local',
     'require module locally in the current .nstrumenta project dir; --name also required here'
   )
   .option('-p, --path <path>', 'specify path (complete filename) of published module')

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -34,7 +34,7 @@ export async function asyncSpawn(
 }
 
 export const getTmpDir = async () => {
-  const cwd = `${__dirname}/tmp`;
+  const cwd = `${__dirname}/.nst`;
 
   try {
     await fs.mkdir(cwd);
@@ -45,13 +45,13 @@ export const getTmpDir = async () => {
   try {
     const stat = await fs.stat(cwd);
     if (!stat.isDirectory()) {
-      throw new Error('no tmp dir');
+      throw new Error('no .nst temp dir');
     }
   } catch (err) {
     console.warn((err as Error).message);
     throw err;
   }
 
-  console.log(`get tmp dir: ${cwd}`);
+  console.log(`get .nst temp dir: ${cwd}`);
   return cwd;
 };

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -4,19 +4,23 @@ import fs from 'fs/promises';
 export async function asyncSpawn(
   cmd: string,
   args?: string[],
-  options?: { cwd?: string; shell?: boolean },
+  options?: { cwd?: string; shell?: boolean; stdio?: 'pipe' | 'inherit' },
   errCB?: (code: number) => void
 ) {
   console.log(`spawn [${cmd} ${args?.join(' ')}]`);
+  args = args || [];
+  options = { ...options };
   const process = spawn(cmd, args, options);
 
   let output = '';
-  for await (const chunk of process.stdout) {
-    output += chunk;
-  }
   let error = '';
-  for await (const chunk of process.stderr) {
-    error += chunk;
+  if (process.stdout && process.stderr) {
+    for await (const chunk of process.stdout) {
+      output += chunk;
+    }
+    for await (const chunk of process.stderr) {
+      error += chunk;
+    }
   }
   const code: number = await new Promise((resolve) => {
     process.on('close', resolve);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -202,7 +202,14 @@ const adapters: Record<ModuleTypes, (module: Module) => Promise<unknown>> = {
       console.log(blue(`[cwd: ${cwd}] npm install...`));
       await asyncSpawn('npm', ['install'], { cwd });
       console.log(blue(`start the module...`));
-      result = await asyncSpawn('npm', ['run', 'start'], { cwd });
+      const apiKey = (config.get('keys') as Keys)[getCurrentContext().projectId];
+      // for now passing apiKey to nodejs module as a command line arg
+      // this may be replaced by messages from the backplane 
+      result = await asyncSpawn(
+        'npm',
+        ['run', 'start', '--', `--apiKey=${apiKey}`],
+        { cwd, stdio: 'inherit', shell: true }
+      );
     } catch (err) {
       console.log('problem', err);
     }

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,16 +1,17 @@
-import { Module, ModuleTypes } from '../commands/publish';
-import fs from 'fs/promises';
-import { createWriteStream, WriteStream } from 'fs';
-import { pipeline as streamPipeline, Stream } from 'stream';
-import { promisify } from 'util';
-import Inquirer from 'inquirer';
-import { asyncSpawn, getTmpDir } from '../cli/utils';
-import { blue, red } from 'colors';
+import axios from 'axios';
+import { blue } from 'colors';
 import Conf from 'conf';
+import { createWriteStream } from 'fs';
+import fs from 'fs/promises';
+import Inquirer from 'inquirer';
+import semver from 'semver';
+import { pipeline as streamPipeline } from 'stream';
+import { promisify } from 'util';
 import { Keys } from '../cli';
+import { asyncSpawn, getTmpDir } from '../cli/utils';
+import { Module, ModuleTypes } from '../commands/publish';
 import { getCurrentContext } from '../lib/context';
 import { schema } from '../schema';
-import axios from 'axios';
 import { endpoints } from '../shared';
 
 const pipeline = promisify(streamPipeline);
@@ -25,16 +26,16 @@ const inquiryForSelectModule = async (choices: string[]): Promise<string> => {
 
 export const Agent = async function ({
   name,
-  noBackplane,
+  local,
   path,
 }: {
   name?: string;
-  noBackplane?: boolean;
+  local?: boolean;
   path?: string;
 }): Promise<void> {
   let module;
 
-  switch (noBackplane) {
+  switch (local) {
     case true:
       module = await useLocalModule(name);
       break;
@@ -44,9 +45,7 @@ export const Agent = async function ({
 
   if (module === undefined) {
     throw new Error(
-      `module: ${blue(name || '--')} isn't defined ${
-        noBackplane ? 'in nstrumenta config' : 'in project'
-      }`
+      `module: ${blue(name || '--')} isn't defined ${local ? 'in nstrumenta config' : 'in project'}`
     );
   }
 
@@ -72,7 +71,12 @@ const useLocalModule = async (moduleName?: string) => {
 
   const modules: Module[] = config.modules;
   if (name === undefined) {
-    name = await inquiryForSelectModule(modules.map((module) => module.name));
+    name = await inquiryForSelectModule(
+      modules
+        .sort((a, b) => semver.compare(a.version, b.version))
+        .reverse()
+        .map((module) => module.name)
+    );
   }
 
   // TODO: (*) get module def from nst-config.json within the module folder
@@ -93,7 +97,7 @@ const getModuleFromStorage = async ({
   name?: string;
   path?: string;
 }): Promise<Module> => {
-  let modules: Record<string, string[]>;
+  let serverModules: Record<string, { path: string; version: string }[]> = {};
   let name = moduleName;
   const apiKey = (config.get('keys') as Keys)[getCurrentContext().projectId];
 
@@ -103,24 +107,26 @@ const getModuleFromStorage = async ({
     headers: { 'x-api-key': apiKey, 'content-type': 'application/json' },
   });
 
-  // TODO: This mess transforms a list of modules in storage into a record
-  //  of module name keys assigned as value a list of the available versions
-  //  maybe it should live somewhere shared
-  modules = response.data.reduce((acc: Record<string, string[]>, next: string) => {
-    const nextAccumulator = { ...acc };
-    const match = /^([^/]+)\/(.*)/.exec(next);
-    const [, module] = match ? match : [];
-    if (module) {
-      nextAccumulator[module] = [...(nextAccumulator[module] ? nextAccumulator[module] : []), next];
+  response.data.forEach((path: string) => {
+    const name = path.split('/')[0];
+    const match = /(\d+)\.(\d+).(\d+)/.exec(path);
+    const version: string = match ? match[0] : '';
+    if (!serverModules[name]) {
+      serverModules[name] = [];
     }
-    return nextAccumulator;
-  }, {});
+    serverModules[name].push({ path, version });
+  });
 
   if (name === undefined && path === undefined) {
     // If user hasn't specified module name, ask for it here
-    name = await inquiryForSelectModule(Object.keys(modules));
-    const chosenModule = await inquiryForSelectModule(modules[name]);
-    path = chosenModule;
+    name = await inquiryForSelectModule(Object.keys(serverModules));
+    const chosenVersion = await inquiryForSelectModule(
+      serverModules[name]
+        .map((module) => module.version)
+        .sort(semver.compare)
+        .reverse()
+    );
+    path = serverModules[name].find((module) => module.version === chosenVersion)?.path;
   }
 
   if (!path) {
@@ -177,7 +183,6 @@ const getModuleFromStorage = async ({
     type: 'nodejs',
     folder,
     version: 'x.x.x',
-    entry: 'index.js',
   };
 };
 
@@ -191,15 +196,13 @@ const adapters: Record<ModuleTypes, (module: Module) => Promise<unknown>> = {
   // For now, run a script with npm dependencies in an environment that has node/npm
   nodejs: async (module) => {
     console.log(`adapt ${module.name} in ${module.folder}`);
-
-    const filename = `${module.folder}/${module.entry}`;
     let result;
     try {
       const cwd = `${module.folder}`;
       console.log(blue(`[cwd: ${cwd}] npm install...`));
       await asyncSpawn('npm', ['install'], { cwd });
       console.log(blue(`start the module...`));
-      result = await asyncSpawn('node', [filename]);
+      result = await asyncSpawn('npm', ['run', 'start'], { cwd });
     } catch (err) {
       console.log('problem', err);
     }


### PR DESCRIPTION
…isions
renames noBackplane to local  (-l, --local) makes more sense
renames the tmp folder to .nst - this wasn't necessary, but makes it easier to find
removes "entry" from the type nodejs, now uses "npm run start"
 
also fixes collisions on the tmp.tar.gz - I was seeing interesting situations with module tarballs, I published successfully, then ran agent start, but the tarball for trax2-serialport contained the tar'ed studio sandbox module.   Now it uses the unique name - could eventually check for file existence before downloading