### PR TITLE
Agent tagging

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "folder": {
             "type": "string",
-            "description": "relative path to folder containing an nstrumenta module with module.json",
+            "description": "relative path to folder containing an nstrumenta module with module.json"
         },
         "name": {
             "type": "string",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -118,6 +118,7 @@ agentCommand
   .option('-p,--port <port>', 'websocket port', DEFAULT_HOST_PORT)
   .option('-d, --debug <debug>', 'output extra debugging', false)
   .option('--project <project>', 'nstrumenta project Id')
+  .option('-t,--tag <tag>', 'optional tag - removes tag from any agent that might already have it')
   .description('start agent')
   .action(Start);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -127,6 +127,7 @@ agentCommand
   .command('set-action')
   .argument('[agentId]', 'agent Id')
   .option('-a,--action <action>', 'action to set')
+  .option('-t,--tag <tag>', 'specify tag in lieu of agentId')
   .description('sets action on agent')
   .action(SetAgentAction);
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -3,13 +3,11 @@ import { resolveApiKey } from '../cli';
 import { NstrumentaServer } from '../lib/server';
 import { DEFAULT_HOST_PORT, endpoints } from '../shared';
 
-export type ListAgentsResponse = [string, object][];
-
-export const Start = async function (options: { port: string }): Promise<void> {
-  const { port } = options;
+export const Start = async function (options: { port: string; tag?: string }): Promise<void> {
+  const { port, tag } = options;
   const apiKey = resolveApiKey();
 
-  const server = new NstrumentaServer({ apiKey, port: port || DEFAULT_HOST_PORT });
+  const server = new NstrumentaServer({ apiKey, port: port || DEFAULT_HOST_PORT, tag });
 
   await server.run();
 };
@@ -61,7 +59,7 @@ export const CleanActions = async (agentId: string) => {
   const apiKey = resolveApiKey();
 
   try {
-    const response = await axios({
+    await axios({
       method: 'POST',
       url: endpoints.CLEAN_AGENT_ACTIONS,
       headers: {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -31,8 +31,8 @@ export const List = async () => {
   }
 };
 
-export const SetAction = async (agentId: string, options: { action: string }) => {
-  const { action: actionString } = options;
+export const SetAction = async (agentId: string, options: { action: string; tag: string }) => {
+  const { action: actionString, tag } = options;
   const action = JSON.parse(actionString);
   const apiKey = resolveApiKey();
 
@@ -44,7 +44,7 @@ export const SetAction = async (agentId: string, options: { action: string }) =>
         contentType: 'application/json',
         'x-api-key': apiKey,
       },
-      data: { agentId, action },
+      data: { action, agentId, tag },
     });
 
     const actionId: string | undefined =

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -46,6 +46,7 @@ export type BackplaneCommand =
 export interface NstrumentaServerOptions {
   apiKey: string;
   port?: string;
+  tag?: string;
   debug?: boolean;
   noBackplane?: boolean;
   allowCrossProjectApiKey?: boolean;
@@ -91,9 +92,11 @@ export class NstrumentaServer {
     if (this.backplaneClient) {
       try {
         //get backplane url
+        const data = this.options.tag ? { tag: this.options.tag } : undefined;
         let response = await axios(endpoints.REGISTER_AGENT, {
           method: 'post',
           headers: { 'x-api-key': apiKey, 'content-type': 'application/json' },
+          data,
         });
         const { backplaneUrl, agentId, actionsCollectionPath } = response.data;
         if (backplaneUrl) {
@@ -137,6 +140,7 @@ export class NstrumentaServer {
               command: 'registerAgent',
               agentId,
               actionsCollectionPath,
+              tag: this.options.tag,
             });
           });
 


### PR DESCRIPTION
* allow to specify tag option on `agent start`
* allow to specify tag option on `agent set-action` which can be used instead of agentId arg