### PR TITLE
Add module metadata

### DIFF
--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { spawn } from 'child_process';
-import { Module, ModuleConfig } from 'commands/module';
+import { ModuleExtended, Module } from 'commands/module';
 import Conf from 'conf';
 import { createWriteStream } from 'fs';
 import { Writable } from 'stream';
@@ -165,7 +165,7 @@ export const getModuleFromStorage = async ({
   name?: string;
   path?: string;
   nonInteractive?: boolean;
-}): Promise<Module> => {
+}): Promise<ModuleExtended> => {
   let serverModules: Record<string, { path: string; version: string }[]> = {};
   let name = moduleName;
   const apiKey = resolveApiKey();
@@ -218,7 +218,7 @@ export const getModuleFromStorage = async ({
   const folder = await getFolderFromStorage(path, { apiKey, baseDir: 'modules' });
   console.log(`saved ${moduleName} to ${folder}`);
 
-  let moduleConfig: ModuleConfig;
+  let moduleConfig: Module;
   try {
     const file = await fs.readFile(`${folder}/module.json`, { encoding: 'utf8' });
     moduleConfig = JSON.parse(file);
@@ -228,7 +228,6 @@ export const getModuleFromStorage = async ({
   }
 
   return {
-    name: name ? name : '',
     folder: folder,
     ...moduleConfig,
   };

--- a/src/commands/module.ts
+++ b/src/commands/module.ts
@@ -259,7 +259,7 @@ export const publishModule = async (module: ModuleExtended) => {
 
   const fileName = `${name}-${version}.tar.gz`;
   const downloadLocation = `${await getNstDir()}/${fileName}`;
-  const remoteFileLocation = `modules/${name}/${fileName}`;
+  const remoteFileLocation = `modules/${name}/versions/${fileName}`;
   let url = '';
   let size = 0;
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -20,4 +20,5 @@ export const endpoints = {
   LIST_MODULES: `${BASE_URL}/listModules`,
   GET_TOKEN: `${BASE_URL}/getToken`,
   VERIFY_TOKEN: `${BASE_URL}/verifyToken`,
+  SET_STORAGE_OBJECT: `${BASE_URL}/setStorageObject`,
 };


### PR DESCRIPTION
add `versions` to storage object path so we can reference as _[collection]/[document]/[collection]..._ in Firestore. Allows setting a document as a one to one relation to the referenced storage object. 

