### PR TITLE
Added ability to set custom 'cwd' on NstrumentaServer.

### DIFF
--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -92,7 +92,7 @@ export const getFolderFromStorage = async (
   options: { apiKey: string; baseDir?: string }
 ) => {
   const { apiKey, baseDir = '' } = options;
-  const nstDir = await getNstDir();
+  const nstDir = await getNstDir(process.cwd());
   const file = `${nodePath.join(nstDir, baseDir, storagePath)}`;
   const extractFolder = nodePath.join(nstDir, baseDir, storagePath.replace('.tar.gz', ''));
   try {
@@ -240,11 +240,11 @@ export function getVersionFromPath(path: string) {
   return version;
 }
 
-export const getNstDir = async () => {
+export const getNstDir = async (cwd: string) => {
   // first look for .nst in cwd
   // agent run creates .nst in it's cwd for supporting
   // multiple independent agents on the same machine
-  const cwdNstDir = `${process.cwd()}/.nst`;
+  const cwdNstDir = `${cwd}/.nst`;
   try {
     const stat = await fs.stat(cwdNstDir);
     if (stat.isDirectory()) {

--- a/src/commands/module.ts
+++ b/src/commands/module.ts
@@ -258,7 +258,7 @@ export const publishModule = async (module: ModuleExtended) => {
   }
 
   const fileName = `${name}-${version}.tar.gz`;
-  const downloadLocation = `${await getNstDir()}/${fileName}`;
+  const downloadLocation = `${await getNstDir(process.cwd())}/${fileName}`;
   const remoteFileLocation = `modules/${name}/versions/${fileName}`;
   let url = '';
   let size = 0;


### PR DESCRIPTION
    * This allows running the server from packaged electron apps where 'process.cwd()' returns '/'.

Simple example usage:

```javascript
const { DEFAULT_HOST_PORT  } = require('./dist/src/shared');
const  { NstrumentaServer } = require('./dist/src/lib/server');

const path = require('path');

let nstServer = null;
async function connectToNst(wsUrl, apiKey) {
  let port = DEFAULT_HOST_PORT;
  const parts = wsUrl.split(':'); // Assuming format of 'ws://localhost:8088'
  if (parts.length === 2) {
    port = parts[1];
  }

  try {
    nstServer = new NstrumentaServer({ apiKey, port, noBackplane: true });
    nstServer.cwd = path.join(__dirname, 'test-folder');
    await nstServer.run();
  } catch (ex) {
    console.error(ex);
  }
}

connectToNst('ws://localhost:8089', 'my-api-key123');
```
