### PR TITLE
chore(client): simplifies websocket code; browser client uses availab…

### DIFF
--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -72,7 +72,7 @@ export class NstrumentaBrowserClient {
     }
 
     this.apiKey = nstrumentaApiKey;
-    this.ws = nodeWebSocket ? new nodeWebSocket(wsUrl) : new WebSocket(wsUrl);
+    this.ws = new WebSocket(wsUrl);
     this.ws.binaryType = 'arraybuffer';
     this.ws.addEventListener('open', async () => {
       console.log(`client websocket opened <${wsUrl}>`);

--- a/src/nodejs/client.ts
+++ b/src/nodejs/client.ts
@@ -71,7 +71,7 @@ export class NstrumentaClient {
     }
 
     this.apiKey = nstrumentaApiKey;
-    this.ws = nodeWebSocket ? new nodeWebSocket(wsUrl) : new WebSocket(wsUrl);
+    this.ws = new WebSocket(wsUrl);
     this.ws.binaryType = 'arraybuffer';
     this.ws.addEventListener('open', async () => {
       console.log(`client websocket opened <${wsUrl}>`);


### PR DESCRIPTION
…e WebSocket constructor, nodejs client uses ws package and ignores any passed in nodeWebsocketOption (still allowed, to avoid breaking change)