### PR TITLE
fix(cli): get method now strips a leading 'projects/PROJECT_ID' from …

### DIFF
--- a/src/cli/commands/data.ts
+++ b/src/cli/commands/data.ts
@@ -227,7 +227,7 @@ export const Get = async (options: DataQueryOptions & { output?: string }) => {
           downloadUrlData,
           downloadUrlConfig
         );
-        const downloadUrl = getDownloadUrl.data;
+        const downloadUrl = getDownloadUrl.data.replace(/^\/?projects\/(\w)+\/?/, '');
 
         const download = await axios.get(downloadUrl, { responseType: 'stream' });
 


### PR DESCRIPTION
…the download url on query