### PR TITLE
feat(module): reduces duplication in module.json

### DIFF
--- a/src/cli/commands/module.ts
+++ b/src/cli/commands/module.ts
@@ -88,19 +88,9 @@ const useLocalModule = async (moduleName?: string): Promise<ModuleExtended> => {
   }
 
   // Read the module configs
-  const promises = config.modules.map(async (moduleMeta) => {
-    const { folder } = moduleMeta;
-    let moduleConfig: Module | undefined;
-    try {
-      moduleConfig = JSON.parse(await fs.readFile(`${folder}/module.json`, { encoding: 'utf8' }));
-    } catch (err) {
-      console.warn(`Couldn't read ${folder}/module.json`);
-    }
-    return { ...moduleMeta, ...moduleConfig };
-  });
 
+  const modules: ModuleExtended[] = await readModuleConfigs(config.modules);
   // Sort the module version
-  const modules: ModuleExtended[] = await Promise.all(promises);
   if (name === undefined) {
     name = await inquiryForSelectModule(
       modules
@@ -185,8 +175,31 @@ export interface ModuleMeta {
 
 export type ModuleExtended = Module & ModuleMeta;
 
+const readModuleConfigs = async (moduleMetas: ModuleMeta[]): Promise<ModuleExtended[]> => {
+  const promises = moduleMetas.map(async (moduleMeta) => {
+    const { folder } = moduleMeta;
+    let moduleConfig: Module | undefined;
+    try {
+      moduleConfig = JSON.parse(await fs.readFile(`${folder}/module.json`, { encoding: 'utf8' }));
+    } catch (err) {
+      console.warn(`Couldn't read ${folder}/module.json`);
+    }
+    let packageConfig: Record<string, unknown> | undefined;
+    try {
+      packageConfig = JSON.parse(await fs.readFile(`${folder}/package.json`, { encoding: 'utf8' }));
+    } catch (err) {
+      console.log(`no ${folder}/package.json`);
+    }
+
+    console.dir({ ...moduleMeta, ...moduleConfig, ...packageConfig });
+
+    return { ...moduleMeta, ...moduleConfig, ...packageConfig } as ModuleExtended;
+  });
+  return Promise.all(promises);
+};
+
 export const Publish = async () => {
-  let modulesMeta: ModuleMeta[];
+  let moduleMetas: ModuleMeta[];
   let modules: ModuleExtended[] = [];
 
   // First, let's check the nst project configuration for modules
@@ -198,28 +211,14 @@ export const Publish = async () => {
     console.log(`cwd: ${process.cwd()}`);
     const { modules: modulesFromFile }: { [key: string]: unknown; modules: ModuleMeta[] } =
       JSON.parse(file);
-    modulesMeta = modulesFromFile;
+    moduleMetas = modulesFromFile;
   } catch (error) {
     throw Error(error as string);
   }
 
   // Now, check for and read the configs
-  // Check each given module for config file
-  const promises = modulesMeta.map(async (meta) => {
-    const { name } = meta;
-    const folder = path.resolve(meta.folder);
 
-    try {
-      const moduleConfig: Module = JSON.parse(
-        await fs.readFile(`${path.resolve(folder)}/module.json`, { encoding: 'utf8' })
-      );
-      return { ...moduleConfig, folder };
-    } catch (e) {
-      console.log(`No config file found in ${path.resolve(folder)}\n`);
-    }
-  });
-
-  const results = await Promise.all(promises);
+  const results = await readModuleConfigs(moduleMetas);
   modules = results.filter((m): m is ModuleExtended => Boolean(m));
 
   console.log(
@@ -257,23 +256,11 @@ export const publishModule = async (module: ModuleExtended) => {
     prePublishCommand,
   } = module;
 
-  // use version from package.json if not specified in module.json
-  let packageVersion = undefined;
-  try {
-    packageVersion = JSON.parse(
-      await fs.readFile(`${folder}/package.json`, {
-        encoding: 'utf8',
-      })
-    ).version;
-  } catch {}
-
-  const moduleVersion = version || packageVersion;
-
-  if (!moduleVersion) {
+  if (!version) {
     throw new Error(`module [${name}] requires version`);
   }
 
-  const fileName = `${name}-${moduleVersion}.tar.gz`;
+  const fileName = `${name}-${version}.tar.gz`;
   const downloadLocation = `${await getNstDir(process.cwd())}/${fileName}`;
   const remoteFileLocation = `modules/${name}/versions/${fileName}`;
   let url = '';

--- a/src/cli/commands/module.ts
+++ b/src/cli/commands/module.ts
@@ -191,8 +191,6 @@ const readModuleConfigs = async (moduleMetas: ModuleMeta[]): Promise<ModuleExten
       console.log(`no ${folder}/package.json`);
     }
 
-    console.dir({ ...moduleMeta, ...moduleConfig, ...packageConfig });
-
     return { ...moduleMeta, ...moduleConfig, ...packageConfig } as ModuleExtended;
   });
   return Promise.all(promises);


### PR DESCRIPTION
spreads params from package.json to avoid needing to specify in many places (i.e. just bump the version in package.json and publish)

I'm using it here:
https://github.com/nst-t/webrtc

.nstrumenta/config.json:
```json
{
  "modules": [
    {
      "folder": "./"
    }
  ]
}
```
./module.json
```json
{
  "type": "sandbox",
  "includes": ["dist/"],
  "prePublishCommand": "npm run build"
}
```

./package.json
```json
{
 {
  "name": "webrtc",
  "version": "0.0.2",
...
}

```
