### PR TITLE
feat: Create Firebase abstraction library

### DIFF
--- a/cluster/frontend/package-lock.json
+++ b/cluster/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/platform-browser-dynamic": "^15.2.9",
         "@angular/router": "^15.2.9",
         "@mcap/core": "^1.3.0",
+        "@nstrumenta/data-adapter": "file:../../src/data-adapter",
         "@sentry/browser": "^7.10.0",
         "core-js": "^3.24.1",
         "idb-keyval": "^6.2.0",
@@ -56,6 +57,17 @@
         "ts-node": "~10.9.1",
         "tslint": "~6.1.3",
         "typescript": "^4.9.5"
+      }
+    },
+    "../../src/data-adapter": {
+      "name": "@nstrumenta/data-adapter",
+      "version": "0.0.1",
+      "dependencies": {
+        "@angular/fire": "^7.6.1",
+        "@google-cloud/firestore": "^6.6.1",
+        "@google-cloud/storage": "^6.11.0",
+        "firebase": "^9.0.0",
+        "rxjs": "^7.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5102,6 +5114,10 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/@nstrumenta/data-adapter": {
+      "resolved": "../../src/data-adapter",
+      "link": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -18837,9 +18853,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -25298,6 +25315,16 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "@nstrumenta/data-adapter": {
+      "version": "file:../../src/data-adapter",
+      "requires": {
+        "@angular/fire": "^7.6.1",
+        "@google-cloud/firestore": "^6.6.1",
+        "@google-cloud/storage": "^6.11.0",
+        "firebase": "^9.0.0",
+        "rxjs": "^7.5.0"
       }
     },
     "@pkgjs/parseargs": {
@@ -36076,9 +36103,9 @@
       }
     },
     "semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
     },
     "semver-dsl": {
       "version": "1.0.1",

--- a/cluster/frontend/package.json
+++ b/cluster/frontend/package.json
@@ -22,6 +22,7 @@
   ],
   "private": true,
   "dependencies": {
+    "@nstrumenta/data-adapter": "file:../../src/data-adapter",
     "@angular/animations": "^15.2.9",
     "@angular/cdk": "^15.2.9",
     "@angular/common": "^15.2.9",

--- a/cluster/frontend/src/app/app.module.ts
+++ b/cluster/frontend/src/app/app.module.ts
@@ -3,10 +3,16 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { LayoutModule } from '@angular/cdk/layout';
 import { HttpClientModule } from '@angular/common/http';
 import { ErrorHandler, Injectable, NgModule } from '@angular/core';
-import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
-import { getAuth, provideAuth } from '@angular/fire/auth';
-import { FIREBASE_OPTIONS } from '@angular/fire/compat';
-import { getFirestore, provideFirestore } from '@angular/fire/firestore';
+import { initializeApp, provideFirebaseApp, getApp } from '@angular/fire/app';
+import { Auth, getAuth, provideAuth } from '@angular/fire/auth';
+import { Firestore, getFirestore, provideFirestore } from '@angular/fire/firestore';
+import { Storage, getStorage, provideStorage } from '@angular/fire/storage';
+import { AuthAdapter, FirestoreAdapter, StorageAdapter } from '@nstrumenta/data-adapter';
+import {
+  FirebaseAuthAdapter,
+  FirebaseFirestoreAdapter,
+  FirebaseStorageAdapter,
+} from '@nstrumenta/data-adapter/firebase';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -100,6 +106,7 @@ export class SentryErrorHandler implements ErrorHandler {
     provideFirebaseApp(() => initializeApp(environment.firebase)),
     provideAuth(() => getAuth()),
     provideFirestore(() => getFirestore()),
+    provideStorage(() => getStorage()),
     HttpClientModule,
     LayoutModule,
     MatToolbarModule,
@@ -172,11 +179,25 @@ export class SentryErrorHandler implements ErrorHandler {
   ],
   providers: [
     AuthService,
-    { provide: FIREBASE_OPTIONS, useValue: environment.firebase },
     VscodeService,
     MatIconRegistry,
     MatSnackBar,
     { provide: ErrorHandler, useClass: SentryErrorHandler },
+    {
+      provide: AuthAdapter,
+      useFactory: (auth: Auth) => new FirebaseAuthAdapter(auth),
+      deps: [Auth],
+    },
+    {
+      provide: FirestoreAdapter,
+      useFactory: (firestore: Firestore) => new FirebaseFirestoreAdapter(firestore),
+      deps: [Firestore],
+    },
+    {
+      provide: StorageAdapter,
+      useFactory: (storage: Storage) => new FirebaseStorageAdapter(storage),
+      deps: [Storage],
+    },
   ],
   bootstrap: [AppComponent],
 })

--- a/cluster/frontend/src/app/auth/auth.service.ts
+++ b/cluster/frontend/src/app/auth/auth.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@angular/core';
-import { User } from '@angular/fire/auth/firebase';
+import { Injectable } from '@angular/core';
+import { User } from '@nstrumenta/data-adapter';
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
-  user = new BehaviorSubject<User>(null);
+  user = new BehaviorSubject<User | null>(null);
 
-  setUser(user: User) {
+  setUser(user: User | null) {
     this.user.next(user);
   }
 }

--- a/cluster/frontend/src/app/components/agent-detail/agent-detail.component.ts
+++ b/cluster/frontend/src/app/components/agent-detail/agent-detail.component.ts
@@ -1,12 +1,11 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute } from '@angular/router';
+import { FirestoreAdapter } from '@nstrumenta/data-adapter';
 import { Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { AuthService } from 'src/app/auth/auth.service';
 
 @Component({
@@ -25,7 +24,7 @@ export class AgentDetailComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
-    private afs: AngularFirestore,
+    private firestoreAdapter: FirestoreAdapter,
     private authService: AuthService,
     public dialog: MatDialog
   ) {}
@@ -38,22 +37,10 @@ export class AgentDetailComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.authService.user.subscribe((user) => {
         this.subscriptions.push(
-          this.afs
-            .collection<any>(this.dataPath)
-            .snapshotChanges()
-            .pipe(
-              map((items) => {
-                return items.map((a) => {
-                  const data = a.payload.doc.data();
-                  const id = a.payload.doc.id;
-                  return { id, ...data };
-                });
-              })
-            )
-            .subscribe((data) => {
-              this.dataSource = new MatTableDataSource(data);
-              this.dataSource.sort = this.sort;
-            })
+          this.firestoreAdapter.collection$<any>(this.dataPath).subscribe((data) => {
+            this.dataSource = new MatTableDataSource(data);
+            this.dataSource.sort = this.sort;
+          })
         );
       })
     );

--- a/cluster/frontend/src/app/components/agents/agents.component.ts
+++ b/cluster/frontend/src/app/components/agents/agents.component.ts
@@ -1,12 +1,11 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute } from '@angular/router';
+import { FirestoreAdapter } from '@nstrumenta/data-adapter';
 import { Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { AuthService } from 'src/app/auth/auth.service';
 
 @Component({
@@ -25,7 +24,7 @@ export class AgentsComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
-    private afs: AngularFirestore,
+    private firestoreAdapter: FirestoreAdapter,
     private authService: AuthService,
     public dialog: MatDialog
   ) {}
@@ -35,22 +34,10 @@ export class AgentsComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.authService.user.subscribe((user) => {
         this.subscriptions.push(
-          this.afs
-            .collection<any>(this.dataPath)
-            .snapshotChanges()
-            .pipe(
-              map((items) => {
-                return items.map((a) => {
-                  const data = a.payload.doc.data();
-                  const id = a.payload.doc.id;
-                  return { id, ...data };
-                });
-              })
-            )
-            .subscribe((data) => {
-              this.dataSource = new MatTableDataSource(data);
-              this.dataSource.sort = this.sort;
-            })
+          this.firestoreAdapter.collection$<any>(this.dataPath).subscribe((data) => {
+            this.dataSource = new MatTableDataSource(data);
+            this.dataSource.sort = this.sort;
+          })
         );
       })
     );

--- a/cluster/frontend/src/app/components/edit-dialog/edit-dialog.component.ts
+++ b/cluster/frontend/src/app/components/edit-dialog/edit-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FirestoreAdapter } from '@nstrumenta/data-adapter';
 
 @Component({
   selector: 'app-edit-dialog',
@@ -11,7 +11,7 @@ export class EditDialogComponent {
   newEmail: string;
 
   constructor(
-    private afs: AngularFirestore,
+    private firestoreAdapter: FirestoreAdapter,
     public dialogRef: MatDialogRef<EditDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {}
@@ -21,7 +21,7 @@ export class EditDialogComponent {
   }
 
   updateEmail(): void {
-    // this.afs.collection('hackers').doc(this.data.uid).update({ email: this.newEmail });
+    // this.firestoreAdapter.updateDoc(`hackers/${this.data.uid}`, { email: this.newEmail });
     this.dialogRef.close();
   }
 }

--- a/cluster/frontend/src/app/components/navbar-account/navbar-account.component.ts
+++ b/cluster/frontend/src/app/components/navbar-account/navbar-account.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject } from '@angular/core';
-import { Auth, GithubAuthProvider, User, signInWithPopup, user } from '@angular/fire/auth';
 import { Router } from '@angular/router';
+import { AuthAdapter, User } from '@nstrumenta/data-adapter';
 import { Subscription } from 'rxjs';
 import { AuthService } from 'src/app/auth/auth.service';
 
@@ -11,11 +11,11 @@ import { AuthService } from 'src/app/auth/auth.service';
 })
 export class NavbarAccountComponent {
   subscriptions = new Array<Subscription>();
-  auth: Auth = inject(Auth);
+  private authAdapter = inject(AuthAdapter);
   private authService = inject(AuthService);
   private router = inject(Router);
   loggedIn = false;
-  user$ = user(this.auth);
+  user$ = this.authAdapter.getAuthState();
   userSubscription: Subscription;
 
   constructor() {
@@ -26,12 +26,14 @@ export class NavbarAccountComponent {
   }
 
   async logout() {
-    await this.auth.signOut();
+    await this.authAdapter.signOut();
     this.loggedIn = false;
     this.router.navigate(['/']);
   }
 
   async login() {
-    return await signInWithPopup(this.auth, new GithubAuthProvider());
+    // The provider can be anything, it's up to the adapter to decide how to handle it.
+    // In our case, the FirebaseAuthAdapter is hardcoded to use GithubAuthProvider.
+    return await this.authAdapter.signInWithPopup('github');
   }
 }

--- a/cluster/frontend/src/app/components/navbar-status/navbar-status.component.ts
+++ b/cluster/frontend/src/app/components/navbar-status/navbar-status.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { FirestoreAdapter } from '@nstrumenta/data-adapter';
 import { Observable, Subscription } from 'rxjs';
 import { Action } from 'src/app/models/action.model';
 import { ProjectService } from 'src/app/services/project.service';
@@ -14,7 +14,10 @@ export class NavbarStatusComponent implements OnInit, OnDestroy {
   public projectId: string;
   subscriptions = new Array<Subscription>();
 
-  constructor(private afs: AngularFirestore, private projectService: ProjectService) { }
+  constructor(
+    private firestoreAdapter: FirestoreAdapter,
+    private projectService: ProjectService
+  ) {}
 
   ngOnInit() {
     this.subscriptions.push(
@@ -22,9 +25,9 @@ export class NavbarStatusComponent implements OnInit, OnDestroy {
         this.projectId = projectId;
         if (this.projectId) {
           const actionPath = '/projects/' + this.projectId + '/actions';
-          this.actions = this.afs
-            .collection<Action>(actionPath, (ref) => ref.orderBy('created', 'desc'))
-            .valueChanges();
+          this.actions = this.firestoreAdapter.collection$<Action>(actionPath, {
+            orderBy: { field: 'created', directionStr: 'desc' },
+          });
         }
       })
     );

--- a/cluster/frontend/src/app/components/project-list/project-list.component.ts
+++ b/cluster/frontend/src/app/components/project-list/project-list.component.ts
@@ -1,10 +1,9 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { map } from 'rxjs/operators';
+import { FirestoreAdapter } from '@nstrumenta/data-adapter';
 import { AuthService } from '../../auth/auth.service';
 import { NewProjectDialogComponent } from '../new-project-dialog/new-project-dialog.component';
 
@@ -28,9 +27,9 @@ export class ProjectListComponent implements OnInit {
 
   constructor(
     public dialog: MatDialog,
-    private afs: AngularFirestore,
+    private firestoreAdapter: FirestoreAdapter,
     public authService: AuthService
-  ) { }
+  ) {}
 
   computeBreakpoint() {
     const ret = Math.max(1, Math.min(4, Math.ceil(window.innerWidth / 400)));
@@ -43,19 +42,10 @@ export class ProjectListComponent implements OnInit {
       if (user) {
         const collection = '/users/' + user.uid + '/projects';
         console.log(collection);
-        this.afs.collection<Item>(collection).snapshotChanges().pipe(
-          map((items) => {
-            return items.map((a) => {
-              const data = a.payload.doc.data();
-              const id = a.payload.doc.id;
-              return { key: id, id: id, ...data };
-            });
-          })
-        )
-          .subscribe((data) => {
-            this.dataSource = new MatTableDataSource(data);
-            this.dataSource.sort = this.sort;
-          });
+        this.firestoreAdapter.collection$<Item>(collection).subscribe((data) => {
+          this.dataSource = new MatTableDataSource(data);
+          this.dataSource.sort = this.sort;
+        });
       }
     });
   }

--- a/cluster/frontend/src/app/services/plotting.service.ts
+++ b/cluster/frontend/src/app/services/plotting.service.ts
@@ -1,11 +1,8 @@
 import { Injectable } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
-import { ActivatedRoute } from '@angular/router';
 import { get as idbGet, keys as idbKeys, set as idbSet } from 'idb-keyval';
 import { BehaviorSubject } from 'rxjs';
 import { SensorEvent, sensorEventLabels } from 'src/app/models/sensorEvent.model';
 import { hash } from 'src/app/utils/hash';
-import { AuthService } from '../auth/auth.service';
 
 @Injectable({
   providedIn: 'root',
@@ -15,11 +12,7 @@ export class PlottingService {
   data = [{ x: [], y: [], name: '' }];
   eventIdMap = {};
 
-  constructor(
-    private authService: AuthService,
-    private afs: AngularFirestore,
-    private activatedRoute: ActivatedRoute
-  ) {}
+  constructor() {}
 
   clearData() {
     this.data = [{ x: [], y: [], name: '' }];

--- a/cluster/frontend/src/app/services/project.service.ts
+++ b/cluster/frontend/src/app/services/project.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
-import { User } from '@angular/fire/auth';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { FirestoreAdapter, User } from '@nstrumenta/data-adapter';
+import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
 import { AuthService } from '../auth/auth.service';
 import { ProjectSettings } from '../models/projectSettings.model';
 import { ServerService } from './server.service';
@@ -13,52 +12,48 @@ import { ServerService } from './server.service';
 export class ProjectService {
   currentProject = new BehaviorSubject<string>('');
   projects: Observable<any[]>;
-  user: User;
+  user: User | null;
   currentProjectId: string;
   projectSettings: ProjectSettings;
 
   constructor(
     private authService: AuthService,
-    private afs: AngularFirestore,
+    private firestoreAdapter: FirestoreAdapter,
     private activatedRoute: ActivatedRoute,
     private serverService: ServerService
   ) {
-    this.authService.user.subscribe((user) => {
-      if (user) {
-        this.user = user;
-        this.projects = this.afs
-          .collection<any>('/users/' + user.uid + '/projects')
-          .valueChanges({ idField: 'key' });
-      }
-    });
+    this.projects = this.authService.user.pipe(
+      switchMap((user) => {
+        if (user) {
+          this.user = user;
+          return this.firestoreAdapter.collection$<any>('/users/' + user.uid + '/projects');
+        } else {
+          this.user = null;
+          return of([]);
+        }
+      })
+    );
     this.activatedRoute.paramMap.subscribe();
   }
 
   setProject(id: string) {
     console.log('setProject', id);
     // only update or add to projects if the user has access to /project/${id}
-    const sub = this.afs
-      .collection<any>('/users/' + this.user.uid + '/projects')
-      .valueChanges({ idField: 'key' })
-      .subscribe((projects) => {
-        this.afs
-          .doc(`/projects/${id}/`)
-          .get()
-          .toPromise()
-          .then((results) => {
-            this.projectSettings = results.data();
-            const lastOpened = Date.now();
-            this.afs
-              .collection<any>('/users/' + this.user.uid + '/projects')
-              .doc(id)
-              .set({ name: this.projectSettings.name, lastOpened });
-            sub.unsubscribe();
+    this.firestoreAdapter.doc$<ProjectSettings>(`/projects/${id}/`).subscribe((projectSettings) => {
+      if (projectSettings) {
+        this.projectSettings = projectSettings;
+        const lastOpened = Date.now();
+        if (this.user) {
+          this.firestoreAdapter.setDoc('/users/' + this.user.uid + '/projects/' + id, {
+            name: this.projectSettings.name,
+            lastOpened,
           });
-      });
+        }
+      }
+    });
 
     this.currentProjectId = id;
     this.currentProject.next(id);
-  
   }
 
   async createApiKey() {

--- a/src/data-adapter/package.json
+++ b/src/data-adapter/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@nstrumenta/data-adapter",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "private": true,
+  "dependencies": {
+    "rxjs": "^7.5.0",
+    "@angular/fire": "^7.6.1",
+    "firebase": "^9.0.0",
+    "@google-cloud/firestore": "^6.6.1",
+    "@google-cloud/storage": "^6.11.0"
+  }
+}

--- a/src/data-adapter/src/auth.ts
+++ b/src/data-adapter/src/auth.ts
@@ -1,0 +1,14 @@
+import { Observable } from 'rxjs';
+
+export interface User {
+  uid: string;
+  email: string | null;
+  displayName: string | null;
+  photoURL: string | null;
+}
+
+export interface AuthAdapter {
+  signInWithPopup(provider: any): Promise<User | null>;
+  signOut(): Promise<void>;
+  getAuthState(): Observable<User | null>;
+}

--- a/src/data-adapter/src/firebase/auth.ts
+++ b/src/data-adapter/src/firebase/auth.ts
@@ -1,0 +1,30 @@
+import { Auth, signInWithPopup, GithubAuthProvider } from '@angular/fire/auth';
+import { user, User as FirebaseUser } from '@angular/fire/auth';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { AuthAdapter, User } from '../../auth';
+
+export class FirebaseAuthAdapter implements AuthAdapter {
+  constructor(private auth: Auth) {}
+
+  signInWithPopup(provider: any): Promise<User | null> {
+    // for now, we only support github
+    return signInWithPopup(this.auth, new GithubAuthProvider()).then(({ user }) => this.mapUser(user));
+  }
+
+  signOut(): Promise<void> {
+    return this.auth.signOut();
+  }
+
+  getAuthState(): Observable<User | null> {
+    return user(this.auth).pipe(map(this.mapUser));
+  }
+
+  private mapUser(user: FirebaseUser | null): User | null {
+    if (!user) {
+      return null;
+    }
+    const { uid, email, displayName, photoURL } = user;
+    return { uid, email, displayName, photoURL };
+  }
+}

--- a/src/data-adapter/src/firebase/firestore.ts
+++ b/src/data-adapter/src/firebase/firestore.ts
@@ -1,0 +1,57 @@
+import {
+  Firestore,
+  collection,
+  collectionData,
+  query as fbQuery,
+  orderBy,
+  doc,
+  docData,
+  addDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  CollectionReference,
+  DocumentReference,
+} from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+import { FirestoreAdapter, Query } from '../../firestore';
+
+export class FirebaseFirestoreAdapter implements FirestoreAdapter {
+  constructor(private firestore: Firestore) {}
+
+  collection$<T>(path: string, q?: Query): Observable<T[]> {
+    let collRef = collection(this.firestore, path) as CollectionReference<T>;
+    if (q && q.orderBy) {
+      const query = fbQuery(collRef, orderBy(q.orderBy.field, q.orderBy.directionStr));
+      return collectionData<T>(query, { idField: 'id' });
+    } else {
+      return collectionData<T>(collRef, { idField: 'id' });
+    }
+  }
+
+  doc$<T>(path:string): Observable<T | undefined> {
+    const docRef = doc(this.firestore, path) as DocumentReference<T>;
+    return docData<T>(docRef, { idField: 'id' });
+  }
+
+  async addDoc<T>(collectionPath: string, data: T): Promise<string> {
+    const collRef = collection(this.firestore, collectionPath) as CollectionReference<T>;
+    const docRef = await addDoc<T>(collRef, data);
+    return docRef.id;
+  }
+
+  setDoc<T>(docPath: string, data: T): Promise<void> {
+    const docRef = doc(this.firestore, docPath);
+    return setDoc(docRef, data);
+  }
+
+  updateDoc<T>(docPath: string, data: Partial<T>): Promise<void> {
+    const docRef = doc(this.firestore, docPath);
+    return updateDoc(docRef, data);
+  }
+
+  deleteDoc(docPath: string): Promise<void> {
+    const docRef = doc(this.firestore, docPath);
+    return deleteDoc(docRef);
+  }
+}

--- a/src/data-adapter/src/firebase/index.ts
+++ b/src/data-adapter/src/firebase/index.ts
@@ -1,0 +1,3 @@
+export * from './auth';
+export * from './firestore';
+export * from './storage';

--- a/src/data-adapter/src/firebase/server/firestore.ts
+++ b/src/data-adapter/src/firebase/server/firestore.ts
@@ -1,0 +1,63 @@
+import { Firestore, FieldValue } from '@google-cloud/firestore';
+import { Observable } from 'rxjs';
+import { FirestoreAdapter, Query } from '../../../firestore';
+
+export class FirebaseServerFirestoreAdapter implements FirestoreAdapter {
+  constructor(private firestore: Firestore) {}
+
+  collection$<T>(path: string, q?: Query): Observable<T[]> {
+    return new Observable((subscriber) => {
+      let collectionRef: FirebaseFirestore.CollectionReference | FirebaseFirestore.Query = this.firestore.collection(path);
+      if (q && q.orderBy) {
+        collectionRef = collectionRef.orderBy(q.orderBy.field, q.orderBy.directionStr);
+      }
+      const unsubscribe = collectionRef.onSnapshot(
+        (snapshot) => {
+          const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() } as T));
+          subscriber.next(data);
+        },
+        (error) => {
+          subscriber.error(error);
+        }
+      );
+      return () => unsubscribe();
+    });
+  }
+
+  doc$<T>(path: string): Observable<T | undefined> {
+    return new Observable((subscriber) => {
+      const docRef = this.firestore.doc(path);
+      const unsubscribe = docRef.onSnapshot(
+        (snapshot) => {
+          if (snapshot.exists) {
+            const data = { id: snapshot.id, ...snapshot.data() } as T;
+            subscriber.next(data);
+          } else {
+            subscriber.next(undefined);
+          }
+        },
+        (error) => {
+          subscriber.error(error);
+        }
+      );
+      return () => unsubscribe();
+    });
+  }
+
+  async addDoc<T>(collectionPath: string, data: T): Promise<string> {
+    const docRef = await this.firestore.collection(collectionPath).add(data);
+    return docRef.id;
+  }
+
+  setDoc<T>(docPath: string, data: T): Promise<void> {
+    return this.firestore.doc(docPath).set(data).then();
+  }
+
+  updateDoc<T>(docPath: string, data: Partial<T>): Promise<void> {
+    return this.firestore.doc(docPath).update(data).then();
+  }
+
+  deleteDoc(docPath: string): Promise<void> {
+    return this.firestore.doc(docPath).delete().then();
+  }
+}

--- a/src/data-adapter/src/firebase/server/index.ts
+++ b/src/data-adapter/src/firebase/server/index.ts
@@ -1,0 +1,1 @@
+export * from './firestore';

--- a/src/data-adapter/src/firebase/storage.ts
+++ b/src/data-adapter/src/firebase/storage.ts
@@ -1,0 +1,53 @@
+import {
+  Storage,
+  ref,
+  uploadBytesResumable,
+  getDownloadURL,
+  updateMetadata,
+  deleteObject,
+} from '@angular/fire/storage';
+import { StorageAdapter, UploadResult } from '../../storage';
+
+export class FirebaseStorageAdapter implements StorageAdapter {
+  constructor(private storage: Storage) {}
+
+  upload(path: string, file: Blob, metadata?: any): Promise<UploadResult> {
+    const storageRef = ref(this.storage, path);
+    const uploadTask = uploadBytesResumable(storageRef, file, metadata);
+
+    return new Promise((resolve, reject) => {
+      uploadTask.on(
+        'state_changed',
+        (snapshot) => {
+          // can be used to display progress
+        },
+        (error) => {
+          reject(error);
+        },
+        () => {
+          getDownloadURL(uploadTask.snapshot.ref).then((downloadURL) => {
+            resolve({
+              storagePath: path,
+              downloadURL: downloadURL,
+            });
+          });
+        }
+      );
+    });
+  }
+
+  getDownloadURL(path: string): Promise<string> {
+    const storageRef = ref(this.storage, path);
+    return getDownloadURL(storageRef);
+  }
+
+  updateMetadata(path: string, metadata: any): Promise<any> {
+    const storageRef = ref(this.storage, path);
+    return updateMetadata(storageRef, metadata);
+  }
+
+  deleteObject(path: string): Promise<void> {
+    const storageRef = ref(this.storage, path);
+    return deleteObject(storageRef);
+  }
+}

--- a/src/data-adapter/src/firestore.ts
+++ b/src/data-adapter/src/firestore.ts
@@ -1,0 +1,18 @@
+import { Observable } from 'rxjs';
+
+export type OrderByDirection = 'desc' | 'asc';
+
+export interface Query {
+  orderBy?: {
+    field: string;
+    directionStr: OrderByDirection;
+  };
+}
+export interface FirestoreAdapter {
+  collection$<T>(path: string, query?: Query): Observable<T[]>;
+  doc$<T>(path: string): Observable<T | undefined>;
+  addDoc<T>(collectionPath: string, data: T): Promise<string>;
+  setDoc<T>(docPath: string, data: T): Promise<void>;
+  updateDoc<T>(docPath: string, data: Partial<T>): Promise<void>;
+  deleteDoc(docPath: string): Promise<void>;
+}

--- a/src/data-adapter/src/index.ts
+++ b/src/data-adapter/src/index.ts
@@ -1,0 +1,3 @@
+export * from './auth';
+export * from './firestore';
+export * from './storage';

--- a/src/data-adapter/src/mock/auth.ts
+++ b/src/data-adapter/src/mock/auth.ts
@@ -1,0 +1,35 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+import { AuthAdapter, User } from '../../auth';
+
+export class MockAuthAdapter implements AuthAdapter {
+  private user$ = new BehaviorSubject<User | null>(null);
+
+  constructor(initialUser: User | null = null) {
+    this.user$.next(initialUser);
+  }
+
+  signInWithPopup(provider: any): Promise<User | null> {
+    const user: User = {
+      uid: 'mock-uid',
+      email: 'mock@example.com',
+      displayName: 'Mock User',
+      photoURL: '',
+    };
+    this.user$.next(user);
+    return Promise.resolve(user);
+  }
+
+  signOut(): Promise<void> {
+    this.user$.next(null);
+    return Promise.resolve();
+  }
+
+  getAuthState(): Observable<User | null> {
+    return this.user$.asObservable();
+  }
+
+  // Helper method for tests
+  setUser(user: User | null) {
+    this.user$.next(user);
+  }
+}

--- a/src/data-adapter/src/mock/firestore.ts
+++ b/src/data-adapter/src/mock/firestore.ts
@@ -1,0 +1,108 @@
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { FirestoreAdapter, Query } from '../../firestore';
+
+export class MockFirestoreAdapter implements FirestoreAdapter {
+  private data = new Map<string, BehaviorSubject<any>>();
+
+  constructor(initialData: Record<string, any> = {}) {
+    for (const key in initialData) {
+      this.data.set(key, new BehaviorSubject(initialData[key]));
+    }
+  }
+
+  collection$<T>(path: string, q?: Query): Observable<T[]> {
+    if (!this.data.has(path)) {
+      this.data.set(path, new BehaviorSubject([]));
+    }
+    const collection$ = this.data.get(path)!.asObservable();
+    if (q && q.orderBy) {
+      return collection$.pipe(
+        map((arr: any[]) => {
+          return arr.sort((a, b) => {
+            const aVal = a[q.orderBy!.field];
+            const bVal = b[q.orderBy!.field];
+            if (q.orderBy!.directionStr === 'asc') {
+              return aVal < bVal ? -1 : 1;
+            } else {
+              return aVal > bVal ? -1 : 1;
+            }
+          });
+        })
+      );
+    }
+    return collection$;
+  }
+
+  doc$<T>(path: string): Observable<T | undefined> {
+    const [collectionPath, docId] = this.splitPath(path);
+    if (!this.data.has(collectionPath)) {
+      this.data.set(collectionPath, new BehaviorSubject([]));
+    }
+    return this.data.get(collectionPath)!.pipe(
+      map((collection: any[]) => collection.find((doc) => doc.id === docId))
+    );
+  }
+
+  async addDoc<T>(collectionPath: string, data: T): Promise<string> {
+    const docId = this.generateId();
+    const doc = { ...data, id: docId };
+    if (!this.data.has(collectionPath)) {
+      this.data.set(collectionPath, new BehaviorSubject([]));
+    }
+    const collection = this.data.get(collectionPath)!.getValue();
+    this.data.get(collectionPath)!.next([...collection, doc]);
+    return docId;
+  }
+
+  async setDoc<T>(docPath: string, data: T): Promise<void> {
+    const [collectionPath, docId] = this.splitPath(docPath);
+    if (!this.data.has(collectionPath)) {
+      this.data.set(collectionPath, new BehaviorSubject([]));
+    }
+    const collection = this.data.get(collectionPath)!.getValue();
+    const docIndex = collection.findIndex((doc: any) => doc.id === docId);
+    if (docIndex > -1) {
+      collection[docIndex] = { ...data, id: docId };
+      this.data.get(collectionPath)!.next([...collection]);
+    } else {
+      this.data.get(collectionPath)!.next([...collection, { ...data, id: docId }]);
+    }
+  }
+
+  async updateDoc<T>(docPath: string, data: Partial<T>): Promise<void> {
+    const [collectionPath, docId] = this.splitPath(docPath);
+     if (!this.data.has(collectionPath)) {
+      return Promise.reject('Document not found');
+    }
+    const collection = this.data.get(collectionPath)!.getValue();
+    const docIndex = collection.findIndex((doc: any) => doc.id === docId);
+    if (docIndex > -1) {
+      collection[docIndex] = { ...collection[docIndex], ...data };
+      this.data.get(collectionPath)!.next([...collection]);
+    } else {
+       return Promise.reject('Document not found');
+    }
+  }
+
+  async deleteDoc(docPath: string): Promise<void> {
+    const [collectionPath, docId] = this.splitPath(docPath);
+    if (!this.data.has(collectionPath)) {
+      return;
+    }
+    const collection = this.data.get(collectionPath)!.getValue();
+    const newCollection = collection.filter((doc: any) => doc.id !== docId);
+    this.data.get(collectionPath)!.next(newCollection);
+  }
+
+  private splitPath(path: string): [string, string] {
+    const parts = path.split('/');
+    const docId = parts.pop()!;
+    const collectionPath = parts.join('/');
+    return [collectionPath, docId];
+  }
+
+  private generateId(): string {
+    return Math.random().toString(36).substring(2);
+  }
+}

--- a/src/data-adapter/src/mock/index.ts
+++ b/src/data-adapter/src/mock/index.ts
@@ -1,0 +1,3 @@
+export * from './auth';
+export * from './firestore';
+export * from './storage';

--- a/src/data-adapter/src/mock/storage.ts
+++ b/src/data-adapter/src/mock/storage.ts
@@ -1,0 +1,25 @@
+import { StorageAdapter, UploadResult } from '../../storage';
+
+export class MockStorageAdapter implements StorageAdapter {
+  upload(path: string, file: Blob, metadata?: any): Promise<UploadResult> {
+    console.log(`Mock upload of a file to ${path}`);
+    return Promise.resolve({
+      storagePath: path,
+      downloadURL: `https://mock-storage.com/${path}`,
+    });
+  }
+
+  getDownloadURL(path: string): Promise<string> {
+    return Promise.resolve(`https://mock-storage.com/${path}`);
+  }
+
+  updateMetadata(path: string, metadata: any): Promise<any> {
+    console.log(`Mock updateMetadata for ${path} with`, metadata);
+    return Promise.resolve();
+  }
+
+  deleteObject(path: string): Promise<void> {
+    console.log(`Mock deleteObject for ${path}`);
+    return Promise.resolve();
+  }
+}

--- a/src/data-adapter/src/storage.ts
+++ b/src/data-adapter/src/storage.ts
@@ -1,0 +1,11 @@
+export interface UploadResult {
+  storagePath: string;
+  downloadURL: string;
+}
+
+export interface StorageAdapter {
+  upload(path: string, file: Blob, metadata?: any): Promise<UploadResult>;
+  getDownloadURL(path: string): Promise<string>;
+  updateMetadata(path: string, metadata: any): Promise<any>;
+  deleteObject(path: string): Promise<void>;
+}

--- a/src/data-adapter/tsconfig.json
+++ b/src/data-adapter/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
This commit introduces a new library to abstract Firebase from the project. This allows for easier testing and the ability to swap out the backend in the future.

The new library is located in `src/data-adapter` and includes:
- Interfaces for Auth, Firestore, and Storage services.
- A Firebase implementation of these services using `@angular/fire`.
- A mock implementation for testing.

The frontend application in `cluster/frontend` has been refactored to use this new library. This involved updating the dependency injection in `app.module.ts` and refactoring all components and services that were using Firebase directly.