### PR TITLE
Fix user settings display broken since v3.1.39

### DIFF
--- a/cluster/frontend/src/app/components/account/account.component.html
+++ b/cluster/frontend/src/app/components/account/account.component.html
@@ -1,4 +1,4 @@
-<div class="account-container">
-  <h2>Account Settings</h2>
-  <p>Account management features will be implemented here.</p>
+<mat-toolbar>User Settings</mat-toolbar>
+<div class="content">
+  <router-outlet></router-outlet>
 </div>

--- a/cluster/frontend/src/app/components/account/account.component.scss
+++ b/cluster/frontend/src/app/components/account/account.component.scss
@@ -1,13 +1,6 @@
 
 .content {
-  display: flex;
-  height: calc(100vh - 42px);
-
-  .nav {
-    overflow: auto;
-  }
-
-  .outlet {
-    flex: 1;
-  }
+  padding: 16px;
+  height: calc(100vh - 64px);
+  overflow: auto;
 }

--- a/cluster/frontend/src/app/components/account/account.component.ts
+++ b/cluster/frontend/src/app/components/account/account.component.ts
@@ -1,9 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { MatToolbar } from '@angular/material/toolbar';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
     selector: 'app-account',
     templateUrl: './account.component.html',
-    styleUrls: ['./account.component.scss']
+    styleUrls: ['./account.component.scss'],
+    imports: [MatToolbar, RouterOutlet]
 })
-export class AccountComponent {
+export class AccountComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
 }

--- a/cluster/frontend/src/app/components/user-profile/user-profile.component.html
+++ b/cluster/frontend/src/app/components/user-profile/user-profile.component.html
@@ -1,5 +1,38 @@
-<mat-list>
-  <mat-list-item>User Id: {{(authService?.user | async)?.uid}}</mat-list-item>
-  <mat-list-item>photoURL: {{(authService?.user | async)?.photoURL}}</mat-list-item>
-  <!-- <mat-list-item>credential: {{authService?.credential?.accessToken}}</mat-list-item> -->
-</mat-list>
+<div class="user-profile">
+  <h2>User Profile</h2>
+  
+  <div class="profile-info">
+    @if ((authService?.user | async)?.photoURL) {
+      <img class="avatar" 
+           [src]="(authService?.user | async)?.photoURL" 
+           [alt]="'User avatar'" />
+    }
+    
+    <div class="user-details">
+      <div class="detail-item">
+        <strong>User ID:</strong>
+        <span class="user-id">{{(authService?.user | async)?.uid}}</span>
+        <button mat-icon-button 
+                [cdkCopyToClipboard]="(authService?.user | async)?.uid || ''"
+                (cdkCopyToClipboardCopied)="onCopied($event)"
+                title="Copy User ID">
+          <mat-icon>content_copy</mat-icon>
+        </button>
+      </div>
+      
+      @if ((authService?.user | async)?.email) {
+        <div class="detail-item">
+          <strong>Email:</strong>
+          <span>{{(authService?.user | async)?.email}}</span>
+        </div>
+      }
+      
+      @if ((authService?.user | async)?.displayName) {
+        <div class="detail-item">
+          <strong>Name:</strong>
+          <span>{{(authService?.user | async)?.displayName}}</span>
+        </div>
+      }
+    </div>
+  </div>
+</div>

--- a/cluster/frontend/src/app/components/user-profile/user-profile.component.scss
+++ b/cluster/frontend/src/app/components/user-profile/user-profile.component.scss
@@ -1,0 +1,65 @@
+.user-profile {
+  padding: 16px;
+}
+
+.profile-info {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.avatar {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-details {
+  flex: 1;
+}
+
+.detail-item {
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.detail-item strong {
+  display: inline-block;
+  min-width: 80px;
+}
+
+.user-id {
+  font-family: monospace;
+  font-weight: bold;
+}
+
+button[mat-icon-button] {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+button[mat-icon-button] mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .profile-info {
+    flex-direction: column;
+  }
+  
+  .detail-item {
+    flex-wrap: wrap;
+  }
+}

--- a/cluster/frontend/src/app/components/user-profile/user-profile.component.ts
+++ b/cluster/frontend/src/app/components/user-profile/user-profile.component.ts
@@ -1,14 +1,26 @@
 import { Component, inject } from '@angular/core';
 import { AuthService } from 'src/app/auth/auth.service';
-import { MatList, MatListItem } from '@angular/material/list';
 import { AsyncPipe } from '@angular/common';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { CdkCopyToClipboard } from '@angular/cdk/clipboard';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
     selector: 'app-user-profile',
     templateUrl: './user-profile.component.html',
     styleUrls: ['./user-profile.component.scss'],
-    imports: [MatList, MatListItem, AsyncPipe]
+    imports: [AsyncPipe, MatIconButton, MatIcon, CdkCopyToClipboard]
 })
 export class UserProfileComponent {
   public authService = inject(AuthService);
+  private snackBar = inject(MatSnackBar);
+
+  onCopied(copied: boolean) {
+    if (copied) {
+      this.snackBar.open('User ID copied to clipboard!', 'Close', {
+        duration: 2000,
+      });
+    }
+  }
 }


### PR DESCRIPTION
- Restore router-outlet in AccountComponent to display UserProfileComponent
- Improve user profile UI with actual avatar image instead of photoURL text
- Add copy button for User ID with clipboard integration and snackbar feedback
- Simplify navigation by removing links to non-existent routes
- Use theme-safe styling to avoid white-on-white text issues
- Make User ID prominent with monospace font and proper labeling

Fixes issue where navigating to /account would not show user information including User ID.
