### PR TITLE
perf: inline Firebase config to eliminate Cloud Run cold start on page load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,28 @@ jobs:
         with:
           workload_identity_provider: ${{ env.CI_WIF_PROVIDER }}
           service_account: ${{ env.CI_SERVICE_ACCOUNT }}
+      - name: Read Firebase config from CI Cloud Run service
+        id: firebase-config
+        run: |
+          ENV_YAML=$(gcloud run services describe cloudrun-service \
+            --project=$CI_PROJECT_ID --region=us-west1 \
+            --format='yaml(spec.template.spec.containers[0].env)')
+          FIREBASE_API_KEY=$(echo "$ENV_YAML" | grep -A1 'name: FIREBASE_API_KEY' | grep 'value:' | awk '{print $2}')
+          FIREBASE_APP_ID=$(echo "$ENV_YAML" | grep -A1 'name: FIREBASE_APP_ID' | grep 'value:' | awk '{print $2}')
+          if [ -z "$FIREBASE_API_KEY" ] || [ -z "$FIREBASE_APP_ID" ]; then
+            echo "::error::Failed to read Firebase config from cloudrun-service"
+            exit 1
+          fi
+          echo "api_key=$FIREBASE_API_KEY" >> "$GITHUB_OUTPUT"
+          echo "app_id=$FIREBASE_APP_ID" >> "$GITHUB_OUTPUT"
+      - name: Inject config into frontend
+        working-directory: frontend
+        run: |
+          FIREBASE_API_KEY=${{ steps.firebase-config.outputs.api_key }} \
+          FIREBASE_APP_ID=${{ steps.firebase-config.outputs.app_id }} \
+          GOOGLE_CLOUD_PROJECT=$CI_PROJECT_ID \
+          BUILD_SHA=${{ github.sha }} \
+          ./inject-config.sh
       - name: Deploy frontend to CI Firebase Hosting
         working-directory: frontend
         run: |
@@ -246,6 +268,28 @@ jobs:
         with:
           workload_identity_provider: ${{ env.PROD_WIF_PROVIDER }}
           service_account: ${{ env.PROD_SERVICE_ACCOUNT }}
+      - name: Read Firebase config from prod Cloud Run service
+        id: firebase-config
+        run: |
+          ENV_YAML=$(gcloud run services describe cloudrun-service \
+            --project=$PROD_PROJECT_ID --region=us-west1 \
+            --format='yaml(spec.template.spec.containers[0].env)')
+          FIREBASE_API_KEY=$(echo "$ENV_YAML" | grep -A1 'name: FIREBASE_API_KEY' | grep 'value:' | awk '{print $2}')
+          FIREBASE_APP_ID=$(echo "$ENV_YAML" | grep -A1 'name: FIREBASE_APP_ID' | grep 'value:' | awk '{print $2}')
+          if [ -z "$FIREBASE_API_KEY" ] || [ -z "$FIREBASE_APP_ID" ]; then
+            echo "::error::Failed to read Firebase config from cloudrun-service"
+            exit 1
+          fi
+          echo "api_key=$FIREBASE_API_KEY" >> "$GITHUB_OUTPUT"
+          echo "app_id=$FIREBASE_APP_ID" >> "$GITHUB_OUTPUT"
+      - name: Inject config into frontend
+        working-directory: frontend
+        run: |
+          FIREBASE_API_KEY=${{ steps.firebase-config.outputs.api_key }} \
+          FIREBASE_APP_ID=${{ steps.firebase-config.outputs.app_id }} \
+          GOOGLE_CLOUD_PROJECT=$PROD_PROJECT_ID \
+          BUILD_SHA=${{ github.sha }} \
+          ./inject-config.sh
       - name: Deploy to Firebase Hosting
         working-directory: frontend
         run: |
@@ -326,6 +370,14 @@ jobs:
             --port=5999 \
             --allow-unauthenticated \
             --update-env-vars="IMAGE_VERSION_TAG=$IMAGE_VERSION_TAG,GOOGLE_CLOUD_PROJECT=$CI_PROJECT_ID,FIREBASE_API_KEY=${{ steps.firebase-config.outputs.api_key }},FIREBASE_APP_ID=${{ steps.firebase-config.outputs.app_id }}"
+      - name: Inject config into frontend
+        working-directory: frontend
+        run: |
+          FIREBASE_API_KEY=${{ steps.firebase-config.outputs.api_key }} \
+          FIREBASE_APP_ID=${{ steps.firebase-config.outputs.app_id }} \
+          GOOGLE_CLOUD_PROJECT=$CI_PROJECT_ID \
+          BUILD_SHA=${{ github.sha }} \
+          ./inject-config.sh
       - name: Deploy frontend to Firebase Hosting preview channel
         id: deploy-hosting
         working-directory: frontend

--- a/frontend/inject-config.sh
+++ b/frontend/inject-config.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+# Injects Firebase config into index.html as window.__NST_CONFIG__ so the
+# frontend can boot without waiting for a Cloud Run cold start on /config.
+#
+# Required env vars: FIREBASE_API_KEY, FIREBASE_APP_ID, GOOGLE_CLOUD_PROJECT
+# Optional env vars: NST_API_URL (defaults to empty, frontend uses window.location.origin)
+#                    BUILD_SHA (git commit sha, shown in navbar)
+#
+# Usage: FIREBASE_API_KEY=... FIREBASE_APP_ID=... GOOGLE_CLOUD_PROJECT=... BUILD_SHA=abc123 ./inject-config.sh [path/to/dist]
+
+DIST_DIR="${1:-dist}"
+INDEX_FILE="$DIST_DIR/index.html"
+
+if [ ! -f "$INDEX_FILE" ]; then
+    echo "Error: $INDEX_FILE not found"
+    exit 1
+fi
+
+for var in FIREBASE_API_KEY FIREBASE_APP_ID GOOGLE_CLOUD_PROJECT; do
+    if [ -z "${!var}" ]; then
+        echo "Error: $var is not set"
+        exit 1
+    fi
+done
+
+PROJECT_ID="$GOOGLE_CLOUD_PROJECT"
+FRONTEND_SHA="${BUILD_SHA:-}"
+CONFIG_JSON=$(cat <<EOF
+{"apiKey":"$FIREBASE_API_KEY","authDomain":"$PROJECT_ID.firebaseapp.com","projectId":"$PROJECT_ID","appId":"$FIREBASE_APP_ID","apiUrl":"${NST_API_URL:-}","frontendSha":"$FRONTEND_SHA"}
+EOF
+)
+
+CONFIG_SCRIPT="<script>window.__NST_CONFIG__=$CONFIG_JSON;</script>"
+
+sed -i "s|</head>|$CONFIG_SCRIPT</head>|" "$INDEX_FILE"
+
+echo "Injected config into $INDEX_FILE"

--- a/frontend/src/app/components/data-table/data-table.component.ts
+++ b/frontend/src/app/components/data-table/data-table.component.ts
@@ -19,6 +19,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { MatIcon } from '@angular/material/icon';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { getNstConfig } from '../../nst-config';
 import { FileSizePipe } from 'src/app/pipes/file-size.pipe';
 import { DataRecord } from 'src/app/models/firebase.model';
 
@@ -354,7 +355,7 @@ export class DataTableComponent implements OnInit {
   async handleModuleAction(moduleAction, fileDocument) {
     console.log(moduleAction, fileDocument);
     if (moduleAction.url) {
-      const config = await fetch('/config').then(res => res.json());
+      const config = await getNstConfig();
       window.open(
         `${moduleAction.url}?org=${config.projectId}&experiment=${fileDocument.filePath}`
       );

--- a/frontend/src/app/components/navbar-title/navbar-title.component.html
+++ b/frontend/src/app/components/navbar-title/navbar-title.component.html
@@ -1,4 +1,5 @@
-<div mat-menu-item class="mat-toolbar" [routerLink]="['/']" queryParamsHandling="preserve">
+<div mat-menu-item class="mat-toolbar" [routerLink]="['/']" queryParamsHandling="preserve"
+     [title]="serverSha ? 'server: ' + serverSha : ''">
   nstrumenta
-  <small>{{version}}</small>
+  <small>{{frontendSha || version}}</small>
 </div>

--- a/frontend/src/app/components/navbar-title/navbar-title.component.ts
+++ b/frontend/src/app/components/navbar-title/navbar-title.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { MatMenuItem } from '@angular/material/menu';
 import { RouterLink } from '@angular/router';
+import { getNstConfig, getServerSha } from '../../nst-config';
 
 @Component({
     selector: 'app-navbar-title',
@@ -11,8 +12,16 @@ import { RouterLink } from '@angular/router';
 })
 export class NavbarTitleComponent {
   version: string;
+  frontendSha = '';
+  serverSha = '';
 
   constructor() {
     this.version = environment.version;
+    getNstConfig().then((config) => {
+      this.frontendSha = config.frontendSha ? config.frontendSha.substring(0, 7) : '';
+    });
+    getServerSha().then((sha) => {
+      this.serverSha = sha ? sha.substring(0, 7) : '';
+    });
   }
 }

--- a/frontend/src/app/nst-config.ts
+++ b/frontend/src/app/nst-config.ts
@@ -1,0 +1,62 @@
+export interface NstConfig {
+  apiKey: string;
+  authDomain: string;
+  projectId: string;
+  appId: string;
+  apiUrl: string;
+  frontendSha?: string;
+  serverSha?: string;
+}
+
+declare global {
+  interface Window {
+    __NST_CONFIG__?: NstConfig;
+  }
+}
+
+let configCache: NstConfig | null = null;
+
+export function getNstConfig(): Promise<NstConfig> {
+  if (configCache) {
+    return Promise.resolve(configCache);
+  }
+
+  if (window.__NST_CONFIG__) {
+    configCache = {
+      ...window.__NST_CONFIG__,
+      apiUrl: window.__NST_CONFIG__.apiUrl || window.location.origin,
+    };
+    return Promise.resolve(configCache);
+  }
+
+  return fetch('/config')
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`Failed to fetch config: ${res.status} ${res.statusText}`);
+      }
+      return res.json();
+    })
+    .then((config: NstConfig) => {
+      configCache = config;
+      return config;
+    });
+}
+
+let serverShaCache: string | null = null;
+
+export function getServerSha(): Promise<string> {
+  if (serverShaCache) {
+    return Promise.resolve(serverShaCache);
+  }
+  if (configCache?.serverSha) {
+    serverShaCache = configCache.serverSha;
+    return Promise.resolve(serverShaCache);
+  }
+  return fetch('/health')
+    .then((res) => res.json())
+    .then((data) => {
+      serverShaCache = data.buildSha || '';
+      return serverShaCache!;
+    })
+    .catch(() => '');
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -3,6 +3,7 @@ import { Injectable, inject } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { map, shareReplay, catchError } from 'rxjs/operators';
 import { AuthService } from '../auth/auth.service';
+import { getNstConfig } from '../nst-config';
 
 export interface CreateProjectRequest {
   name: string;
@@ -72,23 +73,8 @@ export class ApiService {
       return apiUrl;
     }
 
-    // Fetch the API URL from the /config endpoint
-    const response = await fetch('/config');
-    
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch config: ${response.status} ${response.statusText}`
-      );
-    }
-
-    let config: { apiUrl: string };
-    try {
-      config = await response.json();
-    } catch (error) {
-      throw new Error(
-        `Failed to parse config: ${error}`
-      );
-    }
+    // Fetch the API URL from config
+    const config = await getNstConfig();
 
     if (!config.apiUrl) {
       throw new Error(

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,6 +18,7 @@ import { routes } from './app/app-routing.module';
 import { environment } from './environments/environment';
 import { AuthService } from './app/auth/auth.service';
 import { VscodeService } from './app/services/vscode.service';
+import { getNstConfig } from './app/nst-config';
 import * as Sentry from '@sentry/browser';
 
 // Sentry Error Handler
@@ -49,8 +50,7 @@ function initializeIcons() {
   };
 }
 
-fetch('/config')
-  .then((res) => res.json())
+getNstConfig()
   .then((config) => {
     if (environment.production) {
       enableProdMode();

--- a/server/app/src/index.ts
+++ b/server/app/src/index.ts
@@ -69,7 +69,7 @@ registerOrgRoutes(app)
 registerUserRoutes(app)
 
 app.get('/health', (req, res) => {
-  res.status(200).json({ status: 'ok', version })
+  res.status(200).json({ status: 'ok', version, buildSha: nstrumentaImageVersionTag })
 })
 
 app.get('/config', (req, res) => {
@@ -81,7 +81,8 @@ app.get('/config', (req, res) => {
     authDomain: `${projectId}.firebaseapp.com`,
     projectId: projectId,
     appId: process.env.FIREBASE_APP_ID,
-    apiUrl: process.env.NST_API_URL || `${protocol}://${host}`
+    apiUrl: process.env.NST_API_URL || `${protocol}://${host}`,
+    serverSha: nstrumentaImageVersionTag
   })
 })
 


### PR DESCRIPTION
## Problem
Page load from a cold start is slow because the frontend fetches `/config` from Cloud Run, which may need to cold-start before responding.

## Solution
Inject Firebase config directly into `index.html` at deploy time as `window.__NST_CONFIG__`, so the frontend boots immediately without waiting for Cloud Run.

### Changes
- **`frontend/src/app/nst-config.ts`**: Shared `getNstConfig()` reads inline config with fallback to `fetch('/config')` for local dev
- **`frontend/inject-config.sh`**: Stamps Firebase config + frontend build SHA into `index.html` before deploy
- **`server/app/src/index.ts`**: Adds `buildSha` to `/health` and `serverSha` to `/config`
- **Navbar**: Shows frontend commit SHA (server SHA visible on hover)
- **CI**: All 3 deploy paths (CI, prod, PR preview) inject config before Firebase Hosting deploy

### Version Display
The navbar now shows the 7-char git SHA instead of the static `4.2.5` version. Hovering shows the server SHA. Local dev falls back to the package.json version.