### PR TITLE
fix: check MCP isError flag to prevent error messages being used as URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,10 @@ jobs:
           fi
           echo "api_key=$FIREBASE_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app_id=$FIREBASE_APP_ID" >> "$GITHUB_OUTPUT"
+          SERVICE_ACCOUNT=$(gcloud run services describe cloudrun-service \
+            --project=$CI_PROJECT_ID --region=us-west1 \
+            --format='value(spec.template.spec.serviceAccountName)')
+          echo "service_account=$SERVICE_ACCOUNT" >> "$GITHUB_OUTPUT"
       - name: Deploy server to CI Cloud Run
         run: |
           gcloud run deploy pr-${{ github.event.number }} \
@@ -369,6 +373,7 @@ jobs:
             --region=us-west1 \
             --port=5999 \
             --allow-unauthenticated \
+            --service-account=${{ steps.firebase-config.outputs.service_account }} \
             --update-env-vars="IMAGE_VERSION_TAG=$IMAGE_VERSION_TAG,GOOGLE_CLOUD_PROJECT=$CI_PROJECT_ID,FIREBASE_API_KEY=${{ steps.firebase-config.outputs.api_key }},FIREBASE_APP_ID=${{ steps.firebase-config.outputs.app_id }}"
       - name: Inject config into frontend
         working-directory: frontend

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -45,6 +45,19 @@ export class ApiService {
   private http = inject(HttpClient);
   private authService = inject(AuthService);
 
+  private extractMcpResult(response: any, toolName: string): any {
+    if (response.error) {
+      throw new Error(response.error.message || `MCP tool ${toolName} failed`);
+    }
+    if (response.result?.isError) {
+      const errorText = Array.isArray(response.result.content)
+        ? response.result.content.map((c: any) => c.text).join('\n')
+        : `MCP tool ${toolName} returned an error`;
+      throw new Error(errorText);
+    }
+    return response.result?.structuredContent || response.result;
+  }
+
   private async buildMcpHeaders(projectId?: string): Promise<HttpHeaders> {
     const user = this.authService.currentUser();
     if (!user) {
@@ -110,13 +123,7 @@ export class ApiService {
       { headers }
     ).toPromise();
 
-    if (response.error) {
-      console.error('MCP error response:', response.error);
-      throw new Error(response.error.message || 'Failed to create project');
-    }
-
-    // Extract result from MCP response
-    const result = response.result?.structuredContent || response.result;
+    const result = this.extractMcpResult(response, 'create_project');
     return {
       id: result.id,
       slug: result.slug,
@@ -149,12 +156,7 @@ export class ApiService {
       { headers }
     ).toPromise();
 
-    if (response.error) {
-      throw new Error(response.error.message || 'Failed to create API key');
-    }
-
-    // Extract result from MCP response
-    const result = response.result?.structuredContent || response.result;
+    const result = this.extractMcpResult(response, 'create_api_key');
     return {
       key: result.key,
       keyId: result.keyId,
@@ -197,12 +199,8 @@ export class ApiService {
       .post<any>(`${apiUrl}/mcp`, mcpRequest, { headers })
       .toPromise();
 
-    if (mcpResponse.error) {
-      throw new Error(mcpResponse.error.message || 'Failed to get upload URL');
-    }
-
-    const result = mcpResponse.result?.structuredContent || mcpResponse.result;
-    const uploadUrl = result.uploadUrl || (Array.isArray(mcpResponse.result?.content) ? mcpResponse.result.content[0]?.text : undefined);
+    const result = this.extractMcpResult(mcpResponse, 'get_upload_url');
+    const uploadUrl = result.uploadUrl;
 
     if (!uploadUrl) {
       throw new Error('MCP missing uploadUrl in response');
@@ -257,12 +255,8 @@ export class ApiService {
       .post<any>(`${apiUrl}/mcp`, mcpRequest, { headers })
       .toPromise();
 
-    if (mcpResponse.error) {
-      throw new Error(mcpResponse.error.message || 'Failed to get download URL');
-    }
-
-    const result = mcpResponse.result?.structuredContent || mcpResponse.result;
-    const downloadUrl = result.downloadUrl || (Array.isArray(mcpResponse.result?.content) ? mcpResponse.result.content[0]?.text : undefined);
+    const result = this.extractMcpResult(mcpResponse, 'get_download_url');
+    const downloadUrl = result.downloadUrl;
     
     if (!downloadUrl) {
       throw new Error('MCP missing downloadUrl in response');
@@ -289,9 +283,7 @@ export class ApiService {
       .post<any>(`${apiUrl}/mcp`, mcpRequest, { headers })
       .toPromise();
 
-    if (mcpResponse.error) {
-      throw new Error(mcpResponse.error.message || 'Failed to delete file');
-    }
+    this.extractMcpResult(mcpResponse, 'delete_file');
   }
 
 }


### PR DESCRIPTION
## Problem
When an MCP tool throws (e.g. GCS permission error on `get_upload_url`), the SDK returns:
```json
{ "result": { "isError": true, "content": [{ "type": "text", "text": "Failed to get upload URL: ... on resource (or it may not exist)." }] } }
```

The frontend was falling back to `content[0]?.text` as the upload URL, causing the PUT request to go to `https://nstrumenta.com/Failed%20to%20get%20upload%20...`.

## Fix
Add `extractMcpResult()` helper that checks both:
1. Protocol-level errors (`response.error`)
2. Tool-level errors (`response.result.isError`)

All 5 MCP call sites now use this helper, removing the broken `content[0]?.text` fallback.

## Separate issue
The underlying GCS permission error ("Caller does not have storage.objects.create access... or it may not exist") is a server/infra issue — the prod service account may be missing storage permissions for the target bucket.