### PR TITLE
fix(terraform): grant serviceAccountTokenCreator for Cloud Run URL signing

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -330,6 +330,12 @@ resource "google_storage_bucket_iam_member" "app_engine_object_admin" {
   member = "serviceAccount:${data.google_app_engine_default_service_account.default.email}"
 }
 
+resource "google_service_account_iam_member" "app_engine_token_creator" {
+  service_account_id = data.google_app_engine_default_service_account.default.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${data.google_app_engine_default_service_account.default.email}"
+}
+
 
 
 # Firebase Hosting site — serves the Angular SPA from CDN, rewrites API paths to Cloud Run


### PR DESCRIPTION
The App Engine default SA used by Cloud Run needs `iam.serviceAccounts.signBlob` on itself to generate V4 signed URLs. On Cloud Run (no local key file), the `@google-cloud/storage` client calls the IAM Credentials API to sign, which requires `roles/iam.serviceAccountTokenCreator`.

This was manually added to the CI project but never codified in terraform. Prod is currently broken for uploads/downloads.

**To fix prod immediately** (before terraform apply):
```bash
gcloud iam service-accounts add-iam-policy-binding <PROD_SA_EMAIL> \
  --project=<PROD_PROJECT_ID> \
  --member="serviceAccount:<PROD_SA_EMAIL>" \
  --role="roles/iam.serviceAccountTokenCreator"
```