### PR TITLE
fix(frontend): use correct M3 form field patterns app-wide

### DIFF
--- a/frontend/src/app/components/actions/actions.component.html
+++ b/frontend/src/app/components/actions/actions.component.html
@@ -1,6 +1,7 @@
 <div style="flex-direction:row">
-  <mat-form-field>
-    <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-form-field subscriptSizing="dynamic">
+    <mat-icon matPrefix>search</mat-icon>
+    <input matInput (keyup)="applyFilter($event.target.value)" aria-label="Filter" placeholder="Filter" />
   </mat-form-field>
   @if (selection.hasValue()) {
     {{selection.selected.length}} files selected:

--- a/frontend/src/app/components/add-item-dialog/add-item-dialog.component.html
+++ b/frontend/src/app/components/add-item-dialog/add-item-dialog.component.html
@@ -2,10 +2,9 @@
 <mat-dialog-content style='display: flex; flex-direction: column;' class='mat-typography'>
   {{data.description}}
   @for (field of response | keyvalue ; track trackByFn($index, field)) {
-    <mat-form-field class="add-item-form-field"
-      appearance="fill">
-      <input matInput [(ngModel)]='response[field.key]' [placeholder]='field.key'
-        [type]='getFieldType(field.key)'>
+    <mat-form-field class="add-item-form-field">
+      <mat-label>{{ field.key }}</mat-label>
+      <input matInput [(ngModel)]='response[field.key]' [type]='getFieldType(field.key)'>
     </mat-form-field>
   }
 

--- a/frontend/src/app/components/add-item-dialog/add-item-dialog.component.ts
+++ b/frontend/src/app/components/add-item-dialog/add-item-dialog.component.ts
@@ -3,7 +3,7 @@ import { MatDialogRef, MatDialogTitle, MatDialogContent, MatDialogActions, MatDi
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { KeyValuePipe, KeyValue } from '@angular/common';
-import { MatFormField } from '@angular/material/form-field';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
@@ -13,7 +13,7 @@ import { MatButton } from '@angular/material/button';
     selector: 'app-add-item-dialog',
     templateUrl: './add-item-dialog.component.html',
     styleUrls: ['./add-item-dialog.component.css'],
-    imports: [MatDialogTitle, CdkScrollable, MatDialogContent, MatFormField, MatInput, FormsModule, MatDialogActions, MatButton, MatDialogClose, KeyValuePipe]
+    imports: [MatDialogTitle, CdkScrollable, MatDialogContent, MatFormField, MatLabel, MatInput, FormsModule, MatDialogActions, MatButton, MatDialogClose, KeyValuePipe]
 })
 export class AddItemDialogComponent implements OnInit {
   data = inject(MAT_DIALOG_DATA);

--- a/frontend/src/app/components/agent-detail/agent-detail.component.html
+++ b/frontend/src/app/components/agent-detail/agent-detail.component.html
@@ -1,6 +1,7 @@
 <div style="flex-direction:row">
-  <mat-form-field>
-    <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-form-field subscriptSizing="dynamic">
+    <mat-icon matPrefix>search</mat-icon>
+    <input matInput (keyup)="applyFilter($event.target.value)" aria-label="Filter" placeholder="Filter" />
   </mat-form-field>
 </div>
 

--- a/frontend/src/app/components/agent-detail/agent-detail.component.ts
+++ b/frontend/src/app/components/agent-detail/agent-detail.component.ts
@@ -8,12 +8,13 @@ import { Action } from 'src/app/models/action.model';
 import { MatFormField } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { JsonPipe, DatePipe } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'app-agents',
     templateUrl: './agent-detail.component.html',
     styleUrls: ['./agent-detail.component.scss'],
-    imports: [MatFormField, MatInput, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatSortHeader, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, JsonPipe, DatePipe]
+    imports: [MatFormField, MatIcon, MatInput, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatSortHeader, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, JsonPipe, DatePipe]
 })
 export class AgentDetailComponent implements OnChanges {
   @Input() agentId: string;

--- a/frontend/src/app/components/agents/agents.component.html
+++ b/frontend/src/app/components/agents/agents.component.html
@@ -1,6 +1,7 @@
 <div style="flex-direction:row">
-  <mat-form-field>
-    <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-form-field subscriptSizing="dynamic">
+    <mat-icon matPrefix>search</mat-icon>
+    <input matInput (keyup)="applyFilter($event.target.value)" aria-label="Filter" placeholder="Filter" />
   </mat-form-field>
   @if (selection.hasValue()) {
     {{selection.selected.length}} agents selected:

--- a/frontend/src/app/components/agents/agents.component.ts
+++ b/frontend/src/app/components/agents/agents.component.ts
@@ -10,13 +10,14 @@ import { MatInput } from '@angular/material/input';
 import { DatePipe } from '@angular/common';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { Agent } from 'src/app/models/firebase.model';
 
 @Component({
     selector: 'app-agents',
     templateUrl: './agents.component.html',
     styleUrls: ['./agents.component.scss'],
-    imports: [MatFormField, MatInput, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MatButton, RouterLink, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, DatePipe]
+    imports: [MatFormField, MatIcon, MatInput, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MatButton, RouterLink, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, DatePipe]
 })
 export class AgentsComponent {
   displayedColumns = ['select', 'id', 'tag', 'status', 'createdAt'];

--- a/frontend/src/app/components/data-table/data-table.component.html
+++ b/frontend/src/app/components/data-table/data-table.component.html
@@ -1,8 +1,9 @@
 <div style="display: flex; flex-direction: column; gap: 12px; margin-bottom: 16px;">
   <!-- Filter row with view toggle -->
   <div style="display: flex; align-items: center; gap: 16px;">
-    <mat-form-field>
-      <input matInput (keyup)="applyFilter($event.target.value)" [placeholder]="filterParam ?? 'Filter'" />
+    <mat-form-field subscriptSizing="dynamic">
+      <mat-icon matPrefix>search</mat-icon>
+      <input matInput (keyup)="applyFilter($event.target.value)" [attr.aria-label]="filterParam ?? 'Filter'" [placeholder]="filterParam ?? 'Filter'" />
     </mat-form-field>
     <button mat-icon-button (click)="folderNav.toggleFlatView()" 
             [matTooltip]="folderNav.flatView() ? 'Switch to folder view' : 'Switch to flat view'">
@@ -31,7 +32,7 @@
     <span style="flex: 1;"></span>
     
     <!-- New folder controls -->
-    <mat-form-field style="width: 200px;" subscriptSizing="dynamic">
+    <mat-form-field style="width: 200px;">
       <mat-label>New folder name</mat-label>
       <input matInput [(ngModel)]="newFolderName" placeholder="e.g., sensors" 
              (keyup.enter)="createFolder()" />

--- a/frontend/src/app/components/edit-dialog/edit-dialog.component.html
+++ b/frontend/src/app/components/edit-dialog/edit-dialog.component.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-    <input matInput [(ngModel)]="newEmail" placeholder="new email address">
+    <mat-label>New email address</mat-label>
+    <input matInput [(ngModel)]="newEmail">
   </mat-form-field>
   
   <button mat-flat-button (click)="updateEmail()">Save</button>

--- a/frontend/src/app/components/edit-dialog/edit-dialog.component.ts
+++ b/frontend/src/app/components/edit-dialog/edit-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatFormField } from '@angular/material/form-field';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
@@ -9,7 +9,7 @@ import { MatButton } from '@angular/material/button';
     selector: 'app-edit-dialog',
     templateUrl: './edit-dialog.component.html',
     styleUrls: ['./edit-dialog.component.scss'],
-    imports: [MatFormField, MatInput, FormsModule, MatButton]
+    imports: [MatFormField, MatLabel, MatInput, FormsModule, MatButton]
 })
 export class EditDialogComponent {
   dialogRef = inject<MatDialogRef<EditDialogComponent>>(MatDialogRef);

--- a/frontend/src/app/components/login-dialog/login-dialog.component.html
+++ b/frontend/src/app/components/login-dialog/login-dialog.component.html
@@ -12,12 +12,12 @@
   </div>
 
   <form (ngSubmit)="emailLogin()" class="email-form">
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field class="full-width">
       <mat-label>Email</mat-label>
       <input matInput type="email" [(ngModel)]="email" name="email" required>
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field class="full-width">
       <mat-label>Password</mat-label>
       <input matInput type="password" [(ngModel)]="password" name="password" required>
     </mat-form-field>

--- a/frontend/src/app/components/machines/machines.component.html
+++ b/frontend/src/app/components/machines/machines.component.html
@@ -1,6 +1,7 @@
 <div style="flex-direction:row">
-  <mat-form-field>
-    <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-form-field subscriptSizing="dynamic">
+    <mat-icon matPrefix>search</mat-icon>
+    <input matInput (keyup)="applyFilter($event.target.value)" aria-label="Filter" placeholder="Filter" />
   </mat-form-field>
   @if (selection.hasValue()) {
     {{selection.selected.length}} machines selected:

--- a/frontend/src/app/components/modules/modules.component.html
+++ b/frontend/src/app/components/modules/modules.component.html
@@ -1,6 +1,7 @@
 <div style="flex-direction:row">
-  <mat-form-field>
-    <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-form-field subscriptSizing="dynamic">
+    <mat-icon matPrefix>search</mat-icon>
+    <input matInput (keyup)="applyFilter($event.target.value)" aria-label="Filter" placeholder="Filter" />
   </mat-form-field>
   @if (selection.hasValue()) {
     {{selection.selected.length}} modules selected:

--- a/frontend/src/app/components/project-list/project-list.component.html
+++ b/frontend/src/app/components/project-list/project-list.component.html
@@ -1,7 +1,8 @@
 @if (authService.currentUser()) {
   <div class="project-list-container">
     <mat-form-field subscriptSizing="dynamic">
-      <input matInput (input)="filterText.set($event.target.value)" placeholder="Filter projects">
+      <mat-icon matPrefix>search</mat-icon>
+      <input matInput (input)="filterText.set($event.target.value)" aria-label="Filter projects" placeholder="Filter projects" />
     </mat-form-field>
 
     <div class="project-grid">

--- a/frontend/src/app/components/record/record.component.html
+++ b/frontend/src/app/components/record/record.component.html
@@ -3,10 +3,12 @@
 
 <form>
   <mat-form-field style="min-width:300px">
-    <input matInput placeholder="remote url" [(ngModel)]="forwardToWebsocketUrl" name="forwardToWebsocketUrl">
+    <mat-label>Remote URL</mat-label>
+    <input matInput [(ngModel)]="forwardToWebsocketUrl" name="forwardToWebsocketUrl">
   </mat-form-field>
   <mat-form-field style="min-width:300px">
-    <input matInput placeholder="channel" [(ngModel)]="forwardToWebsocketChannel" name="forwardToWebsocketChannel">
+    <mat-label>Channel</mat-label>
+    <input matInput [(ngModel)]="forwardToWebsocketChannel" name="forwardToWebsocketChannel">
   </mat-form-field>
   <button mat-flat-button [matTooltip]="forwardButtonText" (click)="toggleForwardToWebsocket()">
     <mat-icon>cloud_upload</mat-icon> {{forwardButtonText}}

--- a/frontend/src/app/components/record/record.component.ts
+++ b/frontend/src/app/components/record/record.component.ts
@@ -10,7 +10,7 @@ import { map, startWith, takeUntil } from 'rxjs/operators';
 import { FirebaseDataService } from 'src/app/services/firebase-data.service';
 import { SensorEvent, SensorEventId } from 'src/app/models/sensorEvent.model';
 import { FormsModule } from '@angular/forms';
-import { MatFormField } from '@angular/material/form-field';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -44,7 +44,7 @@ export interface NstrumentaExperiment {
     selector: 'app-record',
     templateUrl: './record.component.html',
     styleUrls: ['./record.component.scss'],
-    imports: [FormsModule, MatFormField, MatInput, MatButton, MatTooltip, MatIcon, MatList, MatListItem, MatIconButton, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, KeyValuePipe]
+    imports: [FormsModule, MatFormField, MatLabel, MatInput, MatButton, MatTooltip, MatIcon, MatList, MatListItem, MatIconButton, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, KeyValuePipe]
 })
 export class RecordComponent implements OnInit {
   @ViewChild('previewVideo', { static: false }) previewVideo: ElementRef;

--- a/frontend/src/app/components/repositories/repositories.component.html
+++ b/frontend/src/app/components/repositories/repositories.component.html
@@ -1,6 +1,7 @@
 <div style="flex-direction:row">
-  <mat-form-field>
-    <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-form-field subscriptSizing="dynamic">
+    <mat-icon matPrefix>search</mat-icon>
+    <input matInput (keyup)="applyFilter($event.target.value)" aria-label="Filter" placeholder="Filter" />
   </mat-form-field>
   @if (selection.hasValue()) {
     {{selection.selected.length}} items selected:


### PR DESCRIPTION
## Summary

Fixes incorrect usage of `mat-form-field` across the app. Two distinct patterns now applied correctly:

### Filter/search inputs
- M3 `fill` appearance (framework default)
- `matPrefix` search icon, `placeholder` + `aria-label`
- `subscriptSizing="dynamic"` to avoid reserved hint/error space

### True form fields (login, dialogs, record, profile)
- `mat-label` for proper floating label behavior

### Also fixed
- `add-item-dialog`: replace `appearance="fill"` + placeholder with `mat-label`
- `login-dialog`: remove inconsistent `appearance="outline"` override
- Add `MatLabel`/`MatIcon` imports where missing

No global `MAT_FORM_FIELD_DEFAULT_OPTIONS` — everything uses M3 defaults.