### PR TITLE
Fix project-scoped auth for GitHub installation linking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,8 @@
         "curl": false,
         "wget": false,
         "xargs": false,
-        "eval": false
+        "eval": false,
+        "npx vitest": true
     },
     /* Moves output to the actual Terminal Panel */
     "chat.tools.terminal.outputLocation": "terminal",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -399,24 +399,6 @@
         }
       }
     },
-    "node_modules/@angular-eslint/builder/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-eslint/builder/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -424,7 +406,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -553,24 +534,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@angular-eslint/schematics/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-eslint/schematics/node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
@@ -662,7 +625,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -721,6 +683,7 @@
       "integrity": "sha512-72hskYThlVhktpRCwSwAohY/SxUoMv0hhS71zjlJcHFTzTAWCI8Zy2U4OJuhUO7+XWL6iAu13NKzJKRzUhGdSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "20.2.0",
         "eslint-scope": "^8.0.2"
@@ -750,6 +713,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.6.tgz",
       "integrity": "sha512-SPzTOlkyVagPdb7OMe9hw3dnpMGq2p/nADatzNfRUMXwit8AU8VaiPIrFRsCD52sAL1zDDj60gKsk/dprzIyFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -916,6 +880,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.4.tgz",
       "integrity": "sha512-Zv+q9Z/wVWTt0ckuO3gnU7PbpCLTr1tKPEsofLGGzDufA5/85aBLn2UiLcjlY6wQ+V3EMqANhGo/8XJgvBEYFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -967,6 +932,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.6.tgz",
       "integrity": "sha512-2FcpZ1h6AZ4JwCIlnpHCYrbRTGQTOj/RFXkuX/qw7K6cFmJGfWFMmr++xWtHZEvUddfbR9hqDo+v1mkqEKE/Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -983,6 +949,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.6.tgz",
       "integrity": "sha512-shGkb/aAIPbG8oSYkVJ0msGlRdDVcJBVaUVx2KenMltifQjfLn5N8DFMAzOR6haaA3XeugFExxKqmvySjrVq+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -996,6 +963,7 @@
       "integrity": "sha512-CiPmat4+D+hWXMTAY++09WeII/5D0r6iTjdLdaTq8tlo0uJcrOlazib4CpA94kJ2CRdzfhmC1H+ttwBI1xIlTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1028,6 +996,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.6.tgz",
       "integrity": "sha512-svgK5DhFlQlS+sMybXftn08rHHRiDGY/uIKT5LZUaKgyffnkPb8uClpMIW0NzANtU8qs8pwgDZFoJw85Ia3oqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1053,6 +1022,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.6.tgz",
       "integrity": "sha512-i8BoWxBAm0g2xOMcQ8wTdj07gqMPIFYIyefCOo0ezcGj5XhYjd+C2UrYnKsup0aMZqqEAO1l2aZbmfHx9xLheQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -1099,6 +1069,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.6.tgz",
       "integrity": "sha512-LW1vPXVHvy71LBahn+fSzPlWQl25kJIdcXq+ptG7HsMVgbPQ3/vvkKXAHYaRdppLGCFL+v+3dQGHYLNLiYL9qg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1299,6 +1270,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1707,6 +1679,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1755,6 +1728,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1776,7 +1750,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
       "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-tools": {
       "version": "0.2.21",
@@ -1788,31 +1763,6 @@
         "@electric-sql/pglite": "0.3.16"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1820,7 +1770,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2575,6 +2524,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.10.tgz",
       "integrity": "sha512-PlPhdtjgWUra+LImQTnXOUqUa/jcufZhizdR93ZjlQSS3ahCtDTG6pJw7j0OwFal18DQjICXfeVNsUUrcNisfA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -2641,6 +2591,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.10.tgz",
       "integrity": "sha512-tFmBuZL0/v1h6eyKRgWI58ucft6dEJmAi9nhPUXoAW4ZbPSTlnsh31AuEwUoRTz+wwRk9gmgss9GZV05ZM9Kug==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.10",
         "@firebase/component": "0.7.2",
@@ -2656,7 +2607,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.2",
@@ -3107,6 +3059,7 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3828,6 +3781,7 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -5072,6 +5026,7 @@
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5509,9 +5464,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -5537,9 +5492,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -5555,9 +5510,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6131,6 +6086,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6380,6 +6336,7 @@
       "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.40.0",
         "@typescript-eslint/types": "8.40.0",
@@ -6839,6 +6796,7 @@
       "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6881,6 +6839,7 @@
       "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.57.2",
@@ -7144,6 +7103,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7328,24 +7288,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/angular-eslint/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/angular-eslint/node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
@@ -7437,7 +7379,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -7755,6 +7696,7 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -7911,9 +7853,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8168,6 +8110,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8440,6 +8383,7 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -9934,6 +9878,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10492,6 +10437,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10531,13 +10477,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -10615,9 +10561,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -11554,9 +11500,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -12484,11 +12430,12 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12841,9 +12788,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13954,6 +13901,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -14417,6 +14365,7 @@
       "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -15933,6 +15882,7 @@
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -16097,9 +16047,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -16116,6 +16066,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16301,22 +16252,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -16822,6 +16773,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -18208,7 +18160,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -18292,6 +18245,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18306,6 +18260,7 @@
       "integrity": "sha512-Xvd2l+ZmFDPEt4oj1QEXzA4A2uUK6opvKu3eGN9aGjB8au02lIVcLyi375w94hHyejTOmzIU77L8ol2sRg9n7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.40.0",
         "@typescript-eslint/parser": "8.40.0",
@@ -18769,6 +18724,7 @@
       "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -19155,6 +19111,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -19832,6 +19789,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -19850,7 +19808,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { RecordComponent } from './components/record/record.component';
 import { RepositoriesComponent } from './components/repositories/repositories.component';
 import { UserProfileComponent } from './components/user-profile/user-profile.component';
 import { HomeComponent } from './pages/home/home.component';
+import { AcceptInviteComponent } from './pages/accept-invite/accept-invite.component';
 import { waitlistGuard } from './guards/waitlist.guard';
 import { usernameGuard } from './guards/username.guard';
 import { WaitlistComponent } from './pages/waitlist/waitlist.component';
@@ -41,6 +42,11 @@ const userRoutes: Routes = [
   {
     path: 'waitlist',
     component: WaitlistComponent
+  },
+  {
+    path: 'accept-invite',
+    component: AcceptInviteComponent,
+    canActivate: [waitlistGuard],
   },
   {
     path: 'admin',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import { ProjectSettingsComponent } from './components/project-settings/project-
 import { RecordComponent } from './components/record/record.component';
 import { RepositoriesComponent } from './components/repositories/repositories.component';
 import { UserProfileComponent } from './components/user-profile/user-profile.component';
+import { NotificationsComponent } from './components/notifications/notifications.component';
 import { HomeComponent } from './pages/home/home.component';
 import { AcceptInviteComponent } from './pages/accept-invite/accept-invite.component';
 import { waitlistGuard } from './guards/waitlist.guard';
@@ -69,6 +70,10 @@ const userRoutes: Routes = [
           {
             path: 'profile',
             component: UserProfileComponent,
+          },
+          {
+            path: 'notifications',
+            component: NotificationsComponent,
           },
           {
             path: '',

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -4,7 +4,8 @@ import { AppComponent } from './app.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { AuthService } from './auth/auth.service';
 import { OrganizationService } from './services/organization.service';
-import { MockAuthService } from './testing/mocks';
+import { FirebaseDataService } from './services/firebase-data.service';
+import { MockAuthService, MockFirebaseDataService } from './testing/mocks';
 import { signal } from '@angular/core';
 
 const mockOrganizationService = { organizations: signal([]) };
@@ -16,6 +17,7 @@ describe('AppComponent', () => {
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     providers: [
       { provide: AuthService, useClass: MockAuthService },
+      { provide: FirebaseDataService, useClass: MockFirebaseDataService },
       { provide: OrganizationService, useValue: mockOrganizationService },
     ],
 }).compileComponents();

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -11,6 +11,7 @@ import {
   createUserWithEmailAndPassword,
   sendSignInLinkToEmail,
   isSignInWithEmailLink,
+  signInWithEmailLink,
   EmailAuthProvider,
   linkWithCredential,
 } from 'firebase/auth';
@@ -118,6 +119,18 @@ export class AuthService {
     window.localStorage.setItem(EMAIL_LINK_STORAGE_KEY, normalizedEmail);
   }
 
+  async sendInvitationEmailLink(email: string, continueUrl: string): Promise<void> {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+      throw new Error('Email is required');
+    }
+
+    await sendSignInLinkToEmail(this.auth, normalizedEmail, {
+      url: continueUrl,
+      handleCodeInApp: true,
+    });
+  }
+
   hasPendingEmailLinkInUrl(): boolean {
     return isSignInWithEmailLink(this.auth, window.location.href);
   }
@@ -159,6 +172,24 @@ export class AuthService {
       }
       throw error;
     }
+  }
+
+  async signInWithInvitationEmailLink(email: string): Promise<'signed-in' | 'none'> {
+    if (!isSignInWithEmailLink(this.auth, window.location.href)) {
+      return 'none';
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+      const error: Error & { code?: string } = new Error('Email is required to complete sign-in.');
+      error.code = 'auth/missing-email-for-link';
+      throw error;
+    }
+
+    const result = await signInWithEmailLink(this.auth, normalizedEmail, window.location.href);
+    this.currentUser.set(result.user);
+    this.clearEmailLinkParams();
+    return 'signed-in';
   }
 
   private clearEmailLinkParams(): void {

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -118,14 +118,20 @@ export class AuthService {
     window.localStorage.setItem(EMAIL_LINK_STORAGE_KEY, normalizedEmail);
   }
 
-  async completePendingEmailLink(): Promise<'linked' | 'none'> {
+  hasPendingEmailLinkInUrl(): boolean {
+    return isSignInWithEmailLink(this.auth, window.location.href);
+  }
+
+  async completePendingEmailLink(emailOverride?: string): Promise<'linked' | 'none'> {
     if (!isSignInWithEmailLink(this.auth, window.location.href)) {
       return 'none';
     }
 
-    const pendingEmail = window.localStorage.getItem(EMAIL_LINK_STORAGE_KEY);
+    const pendingEmail = (window.localStorage.getItem(EMAIL_LINK_STORAGE_KEY) || emailOverride || '').trim().toLowerCase();
     if (!pendingEmail) {
-      throw new Error('Missing pending email. Start the add-email flow again from profile.');
+      const error: Error & { code?: string } = new Error('Enter your email address to complete verification.');
+      error.code = 'auth/missing-email-for-link';
+      throw error;
     }
 
     const user = this.currentUser();
@@ -147,6 +153,9 @@ export class AuthService {
         window.localStorage.removeItem(EMAIL_LINK_STORAGE_KEY);
         this.clearEmailLinkParams();
         return 'linked';
+      }
+      if (code === 'auth/credential-already-in-use') {
+        throw new Error('This email is already linked to a different account. Sign in with that account instead.');
       }
       throw error;
     }

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,6 +1,22 @@
 import { Injectable, signal } from '@angular/core';
-import { Auth, User, GoogleAuthProvider, GithubAuthProvider, signInWithPopup, onAuthStateChanged, getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
+import {
+  Auth,
+  User,
+  GoogleAuthProvider,
+  GithubAuthProvider,
+  signInWithPopup,
+  onAuthStateChanged,
+  getAuth,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  sendSignInLinkToEmail,
+  isSignInWithEmailLink,
+  EmailAuthProvider,
+  linkWithCredential,
+} from 'firebase/auth';
 import { Firestore, doc, getFirestore, onSnapshot, Unsubscribe } from 'firebase/firestore';
+
+const EMAIL_LINK_STORAGE_KEY = 'nstrumenta.pendingEmailLinkAddress';
 
 @Injectable({
   providedIn: 'root',
@@ -86,6 +102,62 @@ export class AuthService {
 
   async login(): Promise<void> {
     return this.loginWithGoogle();
+  }
+
+  async sendEmailLinkForCurrentUser(email: string): Promise<void> {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+      throw new Error('Email is required');
+    }
+
+    await sendSignInLinkToEmail(this.auth, normalizedEmail, {
+      url: `${window.location.origin}/account/profile?emailLink=1`,
+      handleCodeInApp: true,
+    });
+
+    window.localStorage.setItem(EMAIL_LINK_STORAGE_KEY, normalizedEmail);
+  }
+
+  async completePendingEmailLink(): Promise<'linked' | 'none'> {
+    if (!isSignInWithEmailLink(this.auth, window.location.href)) {
+      return 'none';
+    }
+
+    const pendingEmail = window.localStorage.getItem(EMAIL_LINK_STORAGE_KEY);
+    if (!pendingEmail) {
+      throw new Error('Missing pending email. Start the add-email flow again from profile.');
+    }
+
+    const user = this.currentUser();
+    if (!user) {
+      throw new Error('Sign in first, then open the email link again to link your email.');
+    }
+
+    try {
+      const credential = EmailAuthProvider.credentialWithLink(pendingEmail, window.location.href);
+      await linkWithCredential(user, credential);
+      await user.reload();
+      this.currentUser.set(this.auth.currentUser);
+      window.localStorage.removeItem(EMAIL_LINK_STORAGE_KEY);
+      this.clearEmailLinkParams();
+      return 'linked';
+    } catch (error: any) {
+      const code = error?.code ?? '';
+      if (code === 'auth/provider-already-linked') {
+        window.localStorage.removeItem(EMAIL_LINK_STORAGE_KEY);
+        this.clearEmailLinkParams();
+        return 'linked';
+      }
+      throw error;
+    }
+  }
+
+  private clearEmailLinkParams(): void {
+    const url = new URL(window.location.href);
+    ['apiKey', 'oobCode', 'mode', 'lang', 'continueUrl', 'emailLink'].forEach((name) => {
+      url.searchParams.delete(name);
+    });
+    window.history.replaceState({}, document.title, `${url.pathname}${url.search}${url.hash}`);
   }
 
   async logout(): Promise<void> {

--- a/frontend/src/app/components/account/account.component.html
+++ b/frontend/src/app/components/account/account.component.html
@@ -1,4 +1,10 @@
-<mat-toolbar>User Settings</mat-toolbar>
+<mat-toolbar>
+  <span>User Settings</span>
+  <span class="toolbar-spacer"></span>
+  @if (authService.currentUser()?.email) {
+    <span class="account-email">{{ authService.currentUser()?.email }}</span>
+  }
+</mat-toolbar>
 <div class="content">
   <router-outlet></router-outlet>
 </div>

--- a/frontend/src/app/components/account/account.component.scss
+++ b/frontend/src/app/components/account/account.component.scss
@@ -1,4 +1,13 @@
 
+.toolbar-spacer {
+  flex: 1;
+}
+
+.account-email {
+  font-size: 0.875rem;
+  opacity: 0.9;
+}
+
 .content {
   padding: 16px;
   height: calc(100vh - 64px);

--- a/frontend/src/app/components/account/account.component.spec.ts
+++ b/frontend/src/app/components/account/account.component.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { signal } from '@angular/core';
 
 import { AccountComponent } from './account.component';
+import { AuthService } from 'src/app/auth/auth.service';
 
 describe('AccountComponent', () => {
   let component: AccountComponent;
@@ -9,8 +12,17 @@ describe('AccountComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-    imports: [AccountComponent],
-}).compileComponents();
+      imports: [AccountComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: {} },
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser: signal({ email: 'test@example.com' }),
+          },
+        },
+      ],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/frontend/src/app/components/account/account.component.ts
+++ b/frontend/src/app/components/account/account.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { MatToolbar } from '@angular/material/toolbar';
 import { RouterOutlet } from '@angular/router';
+import { AuthService } from 'src/app/auth/auth.service';
 
 @Component({
     selector: 'app-account',
@@ -8,4 +9,6 @@ import { RouterOutlet } from '@angular/router';
     styleUrls: ['./account.component.scss'],
     imports: [MatToolbar, RouterOutlet]
 })
-export class AccountComponent {}
+export class AccountComponent {
+    constructor(public authService: AuthService) {}
+}

--- a/frontend/src/app/components/nav/nav.component.html
+++ b/frontend/src/app/components/nav/nav.component.html
@@ -44,6 +44,23 @@
   </mat-sidenav>
   <mat-sidenav-content layout>
     <app-toolbar [projectContext]="projectContext()" (drawerToggleClick)="drawer.toggle()"></app-toolbar>
+    @if (pendingProjectInvitations().length > 0) {
+      <div class="pending-invite-banner-list">
+        @for (invitation of pendingProjectInvitations(); track invitation.invitationId) {
+          <mat-card class="pending-invite-banner">
+            <div class="pending-invite-banner-content">
+              <div class="pending-invite-message">{{ invitation.message }}</div>
+              <a
+                mat-flat-button
+                [routerLink]="['/accept-invite']"
+                [queryParams]="getAcceptInviteQueryParams(invitation)">
+                Review Invite
+              </a>
+            </div>
+          </mat-card>
+        }
+      </div>
+    }
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/frontend/src/app/components/nav/nav.component.html
+++ b/frontend/src/app/components/nav/nav.component.html
@@ -44,23 +44,6 @@
   </mat-sidenav>
   <mat-sidenav-content layout>
     <app-toolbar [projectContext]="projectContext()" (drawerToggleClick)="drawer.toggle()"></app-toolbar>
-    @if (pendingProjectInvitations().length > 0) {
-      <div class="pending-invite-banner-list">
-        @for (invitation of pendingProjectInvitations(); track invitation.invitationId) {
-          <mat-card class="pending-invite-banner">
-            <div class="pending-invite-banner-content">
-              <div class="pending-invite-message">{{ invitation.message }}</div>
-              <a
-                mat-flat-button
-                [routerLink]="['/accept-invite']"
-                [queryParams]="getAcceptInviteQueryParams(invitation)">
-                Review Invite
-              </a>
-            </div>
-          </mat-card>
-        }
-      </div>
-    }
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/frontend/src/app/components/nav/nav.component.scss
+++ b/frontend/src/app/components/nav/nav.component.scss
@@ -31,3 +31,33 @@ mat-nav-list a[mat-list-item] {
   background-color: var(--mat-sys-secondary-container);
   color: var(--mat-sys-on-secondary-container);
 }
+
+.pending-invite-banner-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+}
+
+.pending-invite-banner {
+  border-left: 4px solid var(--mat-sys-tertiary);
+}
+
+.pending-invite-banner-content {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px;
+}
+
+.pending-invite-message {
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .pending-invite-banner-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/app/components/nav/nav.component.ts
+++ b/frontend/src/app/components/nav/nav.component.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { Component, effect, inject } from '@angular/core';
+import { Component, computed, effect, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { map } from 'rxjs/operators';
@@ -9,12 +9,21 @@ import { MatNavList, MatListItem, MatListItemIcon, MatListItemTitle } from '@ang
 import { MatIcon } from '@angular/material/icon';
 import { ToolbarComponent } from '../toolbar/toolbar.component';
 import { FirebaseDataService } from '../../services/firebase-data.service';
+import { MatCard } from '@angular/material/card';
+import { MatButton } from '@angular/material/button';
+
+type PendingProjectInvitation = {
+  message: string;
+  orgId: string;
+  projectId: string;
+  invitationId: string;
+}
 
 @Component({
     selector: 'app-nav',
     templateUrl: './nav.component.html',
     styleUrls: ['./nav.component.scss'],
-    imports: [MatSidenavContainer, MatSidenav, NavbarTitleComponent, MatNavList, MatListItem, MatListItemIcon, MatListItemTitle, RouterLink, RouterLinkActive, MatIcon, MatSidenavContent, ToolbarComponent, RouterOutlet]
+    imports: [MatSidenavContainer, MatSidenav, NavbarTitleComponent, MatNavList, MatListItem, MatListItemIcon, MatListItemTitle, RouterLink, RouterLinkActive, MatIcon, MatSidenavContent, ToolbarComponent, RouterOutlet, MatCard, MatButton]
 })
 export class NavComponent {
   private breakpointObserver = inject(BreakpointObserver);
@@ -30,6 +39,32 @@ export class NavComponent {
     this.route.data.pipe(map(data => !!data['projectContext'])),
     { initialValue: false }
   );
+
+  pendingProjectInvitations = computed<PendingProjectInvitation[]>(() => {
+    const notifications = this.firebaseDataService.notifications();
+    return notifications
+      .filter((notification) => notification?.type === 'project_invitation_pending')
+      .map((notification) => ({
+        message: notification.message || 'You have a pending project invitation.',
+        orgId: String(notification.orgId || ''),
+        projectId: String(notification.projectId || ''),
+        invitationId: String(notification.invitationId || ''),
+      }))
+      .filter((notification) => {
+        if (!notification.invitationId) return false;
+        const [orgId, projectId] = notification.projectId.split('/');
+        return !!orgId && !!projectId;
+      });
+  });
+
+  getAcceptInviteQueryParams(invitation: PendingProjectInvitation) {
+    const [orgId, projectId] = invitation.projectId.split('/');
+    return {
+      orgId,
+      projectId,
+      invitationId: invitation.invitationId,
+    };
+  }
 
   constructor() {
     effect(() => {

--- a/frontend/src/app/components/nav/nav.component.ts
+++ b/frontend/src/app/components/nav/nav.component.ts
@@ -9,21 +9,12 @@ import { MatNavList, MatListItem, MatListItemIcon, MatListItemTitle } from '@ang
 import { MatIcon } from '@angular/material/icon';
 import { ToolbarComponent } from '../toolbar/toolbar.component';
 import { FirebaseDataService } from '../../services/firebase-data.service';
-import { MatCard } from '@angular/material/card';
-import { MatButton } from '@angular/material/button';
-
-type PendingProjectInvitation = {
-  message: string;
-  orgId: string;
-  projectId: string;
-  invitationId: string;
-}
 
 @Component({
     selector: 'app-nav',
     templateUrl: './nav.component.html',
     styleUrls: ['./nav.component.scss'],
-    imports: [MatSidenavContainer, MatSidenav, NavbarTitleComponent, MatNavList, MatListItem, MatListItemIcon, MatListItemTitle, RouterLink, RouterLinkActive, MatIcon, MatSidenavContent, ToolbarComponent, RouterOutlet, MatCard, MatButton]
+    imports: [MatSidenavContainer, MatSidenav, NavbarTitleComponent, MatNavList, MatListItem, MatListItemIcon, MatListItemTitle, RouterLink, RouterLinkActive, MatIcon, MatSidenavContent, ToolbarComponent, RouterOutlet]
 })
 export class NavComponent {
   private breakpointObserver = inject(BreakpointObserver);
@@ -39,32 +30,6 @@ export class NavComponent {
     this.route.data.pipe(map(data => !!data['projectContext'])),
     { initialValue: false }
   );
-
-  pendingProjectInvitations = computed<PendingProjectInvitation[]>(() => {
-    const notifications = this.firebaseDataService.notifications();
-    return notifications
-      .filter((notification) => notification?.type === 'project_invitation_pending')
-      .map((notification) => ({
-        message: notification.message || 'You have a pending project invitation.',
-        orgId: String(notification.orgId || ''),
-        projectId: String(notification.projectId || ''),
-        invitationId: String(notification.invitationId || ''),
-      }))
-      .filter((notification) => {
-        if (!notification.invitationId) return false;
-        const [orgId, projectId] = notification.projectId.split('/');
-        return !!orgId && !!projectId;
-      });
-  });
-
-  getAcceptInviteQueryParams(invitation: PendingProjectInvitation) {
-    const [orgId, projectId] = invitation.projectId.split('/');
-    return {
-      orgId,
-      projectId,
-      invitationId: invitation.invitationId,
-    };
-  }
 
   constructor() {
     effect(() => {

--- a/frontend/src/app/components/navbar-account/navbar-account.component.html
+++ b/frontend/src/app/components/navbar-account/navbar-account.component.html
@@ -5,6 +5,10 @@
         <mat-icon>settings</mat-icon>
         Settings
       </button>
+      <button mat-menu-item [routerLink]="['/account/notifications']" queryParamsHandling="preserve">
+        <mat-icon>notifications</mat-icon>
+        Notifications
+      </button>
       @if (authService.currentUserRole() === 'admin') {
         <button mat-menu-item routerLink="/admin/users">
           <mat-icon>admin_panel_settings</mat-icon>

--- a/frontend/src/app/components/navbar-account/navbar-account.component.html
+++ b/frontend/src/app/components/navbar-account/navbar-account.component.html
@@ -6,7 +6,7 @@
         Settings
       </button>
       <button mat-menu-item [routerLink]="['/account/notifications']" queryParamsHandling="preserve">
-        <mat-icon>notifications</mat-icon>
+        <mat-icon [matBadge]="unreadCount()" [matBadgeHidden]="unreadCount() === 0" matBadgeColor="warn">notifications</mat-icon>
         Notifications
       </button>
       @if (authService.currentUserRole() === 'admin') {
@@ -21,7 +21,8 @@
         Sign out
       </button>
     </mat-menu>
-    <button mat-icon-button [matMenuTriggerFor]="appMenu">
+    <button mat-icon-button [matMenuTriggerFor]="appMenu" 
+      [matBadge]="unreadCount()" [matBadgeHidden]="unreadCount() === 0" matBadgeColor="warn">
       @if (currentUser()?.photoURL) {
         <img class="png-icon avatar-icon"
           [src]="currentUser()?.photoURL" alt="User profile photo" />

--- a/frontend/src/app/components/navbar-account/navbar-account.component.ts
+++ b/frontend/src/app/components/navbar-account/navbar-account.component.ts
@@ -1,27 +1,34 @@
 import { Component, computed, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from 'src/app/auth/auth.service';
+import { FirebaseDataService } from '../../services/firebase-data.service';
 
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { MatIconButton, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatDivider } from '@angular/material/divider';
 import { MatDialog } from '@angular/material/dialog';
+import { MatBadgeModule } from '@angular/material/badge';
 import { LoginDialogComponent } from '../login-dialog/login-dialog.component';
 
 @Component({
     selector: 'app-navbar-account',
     templateUrl: './navbar-account.component.html',
     styleUrls: ['./navbar-account.component.scss'],
-    imports: [MatMenu, MatMenuItem, RouterLink, MatIconButton, MatMenuTrigger, MatIcon, MatButton, MatDivider]
+    imports: [MatMenu, MatMenuItem, RouterLink, MatIconButton, MatMenuTrigger, MatIcon, MatButton, MatDivider, MatBadgeModule]
 })
 export class NavbarAccountComponent {
   authService = inject(AuthService);
   private router = inject(Router);
   private dialog = inject(MatDialog);
+  private firebaseDataService = inject(FirebaseDataService);
 
   currentUser = this.authService.currentUser;
   loggedIn = computed(() => !!this.currentUser());
+
+  unreadCount = computed(() => {
+    return this.firebaseDataService.notifications().filter(n => n && !n['read']).length;
+  });
 
   async logout() {
     await this.authService.logout();

--- a/frontend/src/app/components/notifications/notifications.component.spec.ts
+++ b/frontend/src/app/components/notifications/notifications.component.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { NotificationsComponent } from './notifications.component';
+import { FirebaseDataService } from 'src/app/services/firebase-data.service';
+
+describe('NotificationsComponent', () => {
+  let fixture: ComponentFixture<NotificationsComponent>;
+  let component: NotificationsComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NotificationsComponent],
+      providers: [
+        {
+          provide: FirebaseDataService,
+          useValue: {
+            notifications: signal([
+              {
+                id: 'n1',
+                message: 'You were added to project org1/proj1 as viewer',
+                createdAt: Date.now(),
+              },
+            ]),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotificationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders notification messages', () => {
+    const content = fixture.nativeElement.textContent as string;
+    expect(content).toContain('You were added to project org1/proj1 as viewer');
+  });
+});

--- a/frontend/src/app/components/notifications/notifications.component.ts
+++ b/frontend/src/app/components/notifications/notifications.component.ts
@@ -1,0 +1,56 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
+import { FirebaseDataService } from 'src/app/services/firebase-data.service';
+
+@Component({
+  selector: 'app-notifications',
+  standalone: true,
+  imports: [CommonModule, DatePipe, MatCardModule, MatListModule],
+  template: `
+    <div class="notifications-page">
+      <mat-card>
+        <mat-card-title>Notifications</mat-card-title>
+        <mat-card-content>
+          @if (notifications().length === 0) {
+            <p>No notifications yet.</p>
+          } @else {
+            <mat-list>
+              @for (notification of notifications(); track notification.id ?? $index) {
+                <mat-list-item>
+                  <div class="notification-item">
+                    <div class="message">{{ notification.message || notification.type }}</div>
+                    <div class="time">{{ notification.createdAt | date: 'medium' }}</div>
+                  </div>
+                </mat-list-item>
+              }
+            </mat-list>
+          }
+        </mat-card-content>
+      </mat-card>
+    </div>
+  `,
+  styles: [
+    `
+      .notifications-page {
+        padding: 16px;
+      }
+
+      .notification-item {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .time {
+        font-size: 12px;
+        opacity: 0.7;
+      }
+    `,
+  ],
+})
+export class NotificationsComponent {
+  private firebaseDataService = inject(FirebaseDataService);
+  notifications = this.firebaseDataService.notifications;
+}

--- a/frontend/src/app/components/notifications/notifications.component.ts
+++ b/frontend/src/app/components/notifications/notifications.component.ts
@@ -1,13 +1,15 @@
-import { Component, inject } from '@angular/core';
+import { Component, effect, inject } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
+import { MatButtonModule } from '@angular/material/button';
 import { FirebaseDataService } from 'src/app/services/firebase-data.service';
+import { ApiService } from 'src/app/services/api.service';
 
 @Component({
   selector: 'app-notifications',
   standalone: true,
-  imports: [CommonModule, DatePipe, MatCardModule, MatListModule],
+  imports: [CommonModule, DatePipe, MatCardModule, MatListModule, MatButtonModule],
   template: `
     <div class="notifications-page">
       <mat-card>
@@ -18,10 +20,16 @@ import { FirebaseDataService } from 'src/app/services/firebase-data.service';
           } @else {
             <mat-list>
               @for (notification of notifications(); track notification.id ?? $index) {
-                <mat-list-item>
-                  <div class="notification-item">
+                <mat-list-item class="notification-list-item">
+                  <div class="notification-item" [class.unread]="!notification.read">
                     <div class="message">{{ notification.message || notification.type }}</div>
                     <div class="time">{{ notification.createdAt | date: 'medium' }}</div>
+                    @if (notification.type === 'project_invitation_pending') {
+                      <div class="actions">
+                        <button mat-flat-button color="primary" [disabled]="actionLoading" (click)="acceptInvite(notification)">Accept</button>
+                        <button mat-button color="warn" [disabled]="actionLoading" (click)="declineInvite(notification)">Decline</button>
+                      </div>
+                    }
                   </div>
                 </mat-list-item>
               }
@@ -37,20 +45,84 @@ import { FirebaseDataService } from 'src/app/services/firebase-data.service';
         padding: 16px;
       }
 
+      .notification-list-item {
+        height: auto !important;
+        padding-top: 8px;
+        padding-bottom: 8px;
+      }
+
       .notification-item {
         display: flex;
         flex-direction: column;
         gap: 4px;
+        opacity: 0.8;
+      }
+
+      .notification-item.unread {
+        opacity: 1;
+        font-weight: 500;
       }
 
       .time {
         font-size: 12px;
         opacity: 0.7;
+        font-weight: 400;
+      }
+
+      .actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
       }
     `,
   ],
 })
 export class NotificationsComponent {
   private firebaseDataService = inject(FirebaseDataService);
+  private apiService = inject(ApiService);
   notifications = this.firebaseDataService.notifications;
+  actionLoading = false;
+
+  constructor() {
+    // Mark non-actionable notifications as read when the page is opened.
+    // Pending invitations are only marked read when the user explicitly acts on them.
+    effect(() => {
+      const list = this.notifications();
+      const informational = list.filter(n => !n['read'] && n.id && n['type'] !== 'project_invitation_pending');
+      for (const n of informational) {
+        this.apiService.markNotificationRead(n.id).catch(console.error);
+      }
+    });
+  }
+
+  async acceptInvite(notification: any) {
+    if (!notification.invitationId || !notification.projectId) return;
+    const [orgId, projectId] = notification.projectId.split('/');
+    this.actionLoading = true;
+    try {
+      await this.apiService.acceptProjectInvitation({
+        orgId,
+        projectId,
+        invitationId: notification.invitationId,
+      });
+      // Server deletes the pending notification; nothing else needed here
+    } catch (err) {
+      console.error('Failed to accept invite:', err);
+      alert('Failed to accept: ' + (err instanceof Error ? err.message : String(err)));
+    } finally {
+      this.actionLoading = false;
+    }
+  }
+
+  async declineInvite(notification: any) {
+    if (!notification.id) return;
+    this.actionLoading = true;
+    try {
+      await this.apiService.deleteNotification(notification.id);
+    } catch (err) {
+      console.error('Failed to decline invite:', err);
+    } finally {
+      this.actionLoading = false;
+    }
+  }
 }

--- a/frontend/src/app/components/project-settings/project-settings.component.html
+++ b/frontend/src/app/components/project-settings/project-settings.component.html
@@ -12,8 +12,13 @@
 
 <mat-table #table [dataSource]="membersDataSource" class="animate">
   <ng-container matColumnDef="memberId">
-    <mat-header-cell *matHeaderCellDef> memberId </mat-header-cell>
-    <mat-cell *matCellDef="let member">{{ member.memberId }} </mat-cell>
+    <mat-header-cell *matHeaderCellDef> member </mat-header-cell>
+    <mat-cell *matCellDef="let member">
+      {{ member.email || member.memberId }}
+      @if (member.kind === 'invitation') {
+        <span class="pending-chip">pending</span>
+      }
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="role">
@@ -44,7 +49,7 @@
     <mat-header-cell *matHeaderCellDef></mat-header-cell>
     <mat-cell *matCellDef="let member">
       @if (canRemoveMember(member)) {
-        <button mat-button (click)="removeMember(member)">Remove</button>
+        <button mat-button (click)="removeMember(member)">{{ member.kind === 'invitation' ? 'Cancel' : 'Remove' }}</button>
       }
     </mat-cell>
   </ng-container>

--- a/frontend/src/app/components/project-settings/project-settings.component.html
+++ b/frontend/src/app/components/project-settings/project-settings.component.html
@@ -18,18 +18,31 @@
 
   <ng-container matColumnDef="role">
     <mat-header-cell *matHeaderCellDef> role </mat-header-cell>
-    <mat-cell *matCellDef="let member">{{ member.role }} </mat-cell>
+    <mat-cell *matCellDef="let member">
+      @let roles = availableRoles(member);
+      <div class="member-role-cell">
+        @if (roles.length > 0) {
+          <button mat-button class="member-role-chip" [matMenuTriggerFor]="roleMenu">
+            <span>{{ member.role }}</span>
+            <mat-icon>arrow_drop_down</mat-icon>
+          </button>
+          <mat-menu #roleMenu="matMenu">
+            @for (role of roles; track role) {
+              <button mat-menu-item (click)="setMemberRole(member, role)">{{ role }}</button>
+            }
+          </mat-menu>
+        } @else {
+          <button mat-button disabled class="member-role-chip is-static">
+            <span>{{ member.role }}</span>
+          </button>
+        }
+      </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="action">
-    <mat-header-cell *matHeaderCellDef> action </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
     <mat-cell *matCellDef="let member">
-      @if (canSetRole(member, 'admin')) {
-        <button mat-button (click)="setMemberRole(member, 'admin')">Make admin</button>
-      }
-      @if (canSetRole(member, 'viewer')) {
-        <button mat-button (click)="setMemberRole(member, 'viewer')">Make viewer</button>
-      }
       @if (canRemoveMember(member)) {
         <button mat-button (click)="removeMember(member)">Remove</button>
       }

--- a/frontend/src/app/components/project-settings/project-settings.component.html
+++ b/frontend/src/app/components/project-settings/project-settings.component.html
@@ -21,6 +21,21 @@
     <mat-cell *matCellDef="let member">{{ member.role }} </mat-cell>
   </ng-container>
 
+  <ng-container matColumnDef="action">
+    <mat-header-cell *matHeaderCellDef> action </mat-header-cell>
+    <mat-cell *matCellDef="let member">
+      @if (canSetRole(member, 'admin')) {
+        <button mat-button (click)="setMemberRole(member, 'admin')">Make admin</button>
+      }
+      @if (canSetRole(member, 'viewer')) {
+        <button mat-button (click)="setMemberRole(member, 'viewer')">Make viewer</button>
+      }
+      @if (canRemoveMember(member)) {
+        <button mat-button (click)="removeMember(member)">Remove</button>
+      }
+    </mat-cell>
+  </ng-container>
+
 
 
   <mat-header-row *matHeaderRowDef="membersDisplayedColumns"></mat-header-row>

--- a/frontend/src/app/components/project-settings/project-settings.component.html
+++ b/frontend/src/app/components/project-settings/project-settings.component.html
@@ -7,6 +7,8 @@
   </mat-list-item>
 </mat-list>
 
+<button mat-flat-button (click)="inviteMember()">Invite Member</button>
+
 
 <mat-table #table [dataSource]="membersDataSource" class="animate">
   <ng-container matColumnDef="memberId">

--- a/frontend/src/app/components/project-settings/project-settings.component.spec.ts
+++ b/frontend/src/app/components/project-settings/project-settings.component.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProjectSettingsComponent } from './project-settings.component';
 import { ActivatedRoute } from '@angular/router';
@@ -9,21 +9,34 @@ import { ServerService } from 'src/app/services/server.service';
 import { MatDialog } from '@angular/material/dialog';
 import { MockActivatedRoute, MockAuthService, MockFirebaseDataService, MockProjectService, MockServerService } from 'src/app/testing/mocks';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
 
 describe('ProjectSettingsComponent', () => {
   let component: ProjectSettingsComponent;
   let fixture: ComponentFixture<ProjectSettingsComponent>;
+  let dialogMock: { open: ReturnType<typeof vi.fn> };
+  let projectServiceMock: { inviteProjectMember: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
+    dialogMock = {
+      open: vi.fn().mockReturnValue({
+        afterClosed: () => of(undefined),
+      }),
+    };
+
+    projectServiceMock = {
+      inviteProjectMember: vi.fn().mockResolvedValue(undefined),
+    };
+
     TestBed.configureTestingModule({
       imports: [ProjectSettingsComponent, NoopAnimationsModule],
       providers: [
         { provide: ActivatedRoute, useClass: MockActivatedRoute },
         { provide: AuthService, useClass: MockAuthService },
         { provide: FirebaseDataService, useClass: MockFirebaseDataService },
-        { provide: ProjectService, useClass: MockProjectService },
+        { provide: ProjectService, useValue: projectServiceMock },
         { provide: ServerService, useClass: MockServerService },
-        { provide: MatDialog, useValue: {} }
+        { provide: MatDialog, useValue: dialogMock }
       ]
     }).compileComponents();
   });
@@ -36,5 +49,19 @@ describe('ProjectSettingsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('opens invite dialog and calls project service with dialog response', () => {
+    dialogMock.open.mockReturnValue({
+      afterClosed: () => of({ email: 'new@example.com', role: 'viewer' }),
+    });
+
+    component.inviteMember();
+
+    expect(dialogMock.open).toHaveBeenCalled();
+    expect(projectServiceMock.inviteProjectMember).toHaveBeenCalledWith({
+      email: 'new@example.com',
+      role: 'viewer',
+    });
   });
 });

--- a/frontend/src/app/components/project-settings/project-settings.component.spec.ts
+++ b/frontend/src/app/components/project-settings/project-settings.component.spec.ts
@@ -7,15 +7,20 @@ import { FirebaseDataService } from 'src/app/services/firebase-data.service';
 import { ProjectService } from 'src/app/services/project.service';
 import { ServerService } from 'src/app/services/server.service';
 import { MatDialog } from '@angular/material/dialog';
-import { MockActivatedRoute, MockAuthService, MockFirebaseDataService, MockProjectService, MockServerService } from 'src/app/testing/mocks';
+import { MockActivatedRoute, MockServerService } from 'src/app/testing/mocks';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
+import { signal } from '@angular/core';
 
 describe('ProjectSettingsComponent', () => {
   let component: ProjectSettingsComponent;
   let fixture: ComponentFixture<ProjectSettingsComponent>;
   let dialogMock: { open: ReturnType<typeof vi.fn> };
-  let projectServiceMock: { inviteProjectMember: ReturnType<typeof vi.fn> };
+  let projectServiceMock: {
+    inviteProjectMember: ReturnType<typeof vi.fn>;
+    updateProjectMemberRole: ReturnType<typeof vi.fn>;
+    removeProjectMember: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
     dialogMock = {
@@ -26,14 +31,34 @@ describe('ProjectSettingsComponent', () => {
 
     projectServiceMock = {
       inviteProjectMember: vi.fn().mockResolvedValue(undefined),
+      updateProjectMemberRole: vi.fn().mockResolvedValue(undefined),
+      removeProjectMember: vi.fn().mockResolvedValue(undefined),
     };
 
     TestBed.configureTestingModule({
       imports: [ProjectSettingsComponent, NoopAnimationsModule],
       providers: [
         { provide: ActivatedRoute, useClass: MockActivatedRoute },
-        { provide: AuthService, useClass: MockAuthService },
-        { provide: FirebaseDataService, useClass: MockFirebaseDataService },
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser: signal({ uid: 'owner1' }),
+          },
+        },
+        {
+          provide: FirebaseDataService,
+          useValue: {
+            projectId: () => 'org1/proj1',
+            projectSettings: signal({
+              members: {
+                owner1: 'owner',
+                admin1: 'admin',
+                viewer1: 'viewer',
+              },
+              apiKeys: {},
+            }),
+          },
+        },
         { provide: ProjectService, useValue: projectServiceMock },
         { provide: ServerService, useClass: MockServerService },
         { provide: MatDialog, useValue: dialogMock }
@@ -63,5 +88,23 @@ describe('ProjectSettingsComponent', () => {
       email: 'new@example.com',
       role: 'viewer',
     });
+  });
+
+  it('allows owner to promote viewer to admin', () => {
+    component.setMemberRole({ memberId: 'viewer1', role: 'viewer' }, 'admin');
+    expect(projectServiceMock.updateProjectMemberRole).toHaveBeenCalledWith({
+      memberId: 'viewer1',
+      role: 'admin',
+    });
+  });
+
+  it('opens confirmation and removes member when confirmed', () => {
+    dialogMock.open.mockReturnValue({
+      afterClosed: () => of(true),
+    });
+
+    component.removeMember({ memberId: 'viewer1', role: 'viewer' });
+
+    expect(projectServiceMock.removeProjectMember).toHaveBeenCalledWith('viewer1');
   });
 });

--- a/frontend/src/app/components/project-settings/project-settings.component.spec.ts
+++ b/frontend/src/app/components/project-settings/project-settings.component.spec.ts
@@ -11,15 +11,22 @@ import { MockActivatedRoute, MockServerService } from 'src/app/testing/mocks';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { signal } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 describe('ProjectSettingsComponent', () => {
   let component: ProjectSettingsComponent;
   let fixture: ComponentFixture<ProjectSettingsComponent>;
   let dialogMock: { open: ReturnType<typeof vi.fn> };
+  let snackBarMock: { open: ReturnType<typeof vi.fn> };
+  let authServiceMock: {
+    currentUser: ReturnType<typeof signal<any>>;
+    sendInvitationEmailLink: ReturnType<typeof vi.fn>;
+  };
   let projectServiceMock: {
     inviteProjectMember: ReturnType<typeof vi.fn>;
     updateProjectMemberRole: ReturnType<typeof vi.fn>;
     removeProjectMember: ReturnType<typeof vi.fn>;
+    revokeProjectInvitation: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(async () => {
@@ -29,10 +36,28 @@ describe('ProjectSettingsComponent', () => {
       }),
     };
 
+    snackBarMock = {
+      open: vi.fn(),
+    };
+
+    authServiceMock = {
+      currentUser: signal({ uid: 'owner1' }),
+      sendInvitationEmailLink: vi.fn().mockResolvedValue(undefined),
+    };
+
     projectServiceMock = {
-      inviteProjectMember: vi.fn().mockResolvedValue(undefined),
+      inviteProjectMember: vi.fn().mockResolvedValue({
+        existingUser: true,
+        requiresEmailBootstrap: false,
+        firebaseEmailLink: {
+          email: 'new@example.com',
+          continueUrl: 'https://app.example.com/accept-invite?orgId=org1&projectId=proj1&invitationId=invite-1',
+          handleCodeInApp: true,
+        },
+      }),
       updateProjectMemberRole: vi.fn().mockResolvedValue(undefined),
       removeProjectMember: vi.fn().mockResolvedValue(undefined),
+      revokeProjectInvitation: vi.fn().mockResolvedValue(undefined),
     };
 
     TestBed.configureTestingModule({
@@ -41,9 +66,7 @@ describe('ProjectSettingsComponent', () => {
         { provide: ActivatedRoute, useClass: MockActivatedRoute },
         {
           provide: AuthService,
-          useValue: {
-            currentUser: signal({ uid: 'owner1' }),
-          },
+          useValue: authServiceMock,
         },
         {
           provide: FirebaseDataService,
@@ -57,11 +80,20 @@ describe('ProjectSettingsComponent', () => {
               },
               apiKeys: {},
             }),
+            projectInvitations: signal([
+              {
+                id: 'invite-1',
+                email: 'pending@example.com',
+                role: 'viewer',
+                status: 'pending',
+              },
+            ]),
           },
         },
         { provide: ProjectService, useValue: projectServiceMock },
         { provide: ServerService, useClass: MockServerService },
-        { provide: MatDialog, useValue: dialogMock }
+        { provide: MatDialog, useValue: dialogMock },
+        { provide: MatSnackBar, useValue: snackBarMock },
       ]
     }).compileComponents();
   });
@@ -76,22 +108,29 @@ describe('ProjectSettingsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('opens invite dialog and calls project service with dialog response', () => {
+  it('opens invite dialog and calls project service with dialog response', async () => {
     dialogMock.open.mockReturnValue({
       afterClosed: () => of({ email: 'new@example.com', role: 'viewer' }),
     });
 
     component.inviteMember();
+    await fixture.whenStable();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(dialogMock.open).toHaveBeenCalled();
     expect(projectServiceMock.inviteProjectMember).toHaveBeenCalledWith({
       email: 'new@example.com',
       role: 'viewer',
     });
+    expect(authServiceMock.sendInvitationEmailLink).toHaveBeenCalledWith(
+      'new@example.com',
+      'https://app.example.com/accept-invite?orgId=org1&projectId=proj1&invitationId=invite-1',
+    );
+    expect(snackBarMock.open).toHaveBeenCalledWith('Invitation created. Email sent and user can accept in app.', 'Close', { duration: 4000 });
   });
 
   it('allows owner to promote viewer to admin', () => {
-    component.setMemberRole({ memberId: 'viewer1', role: 'viewer' }, 'admin');
+    component.setMemberRole({ kind: 'member', memberId: 'viewer1', role: 'viewer' }, 'admin');
     expect(projectServiceMock.updateProjectMemberRole).toHaveBeenCalledWith({
       memberId: 'viewer1',
       role: 'admin',
@@ -103,8 +142,33 @@ describe('ProjectSettingsComponent', () => {
       afterClosed: () => of(true),
     });
 
-    component.removeMember({ memberId: 'viewer1', role: 'viewer' });
+    component.removeMember({ kind: 'member', memberId: 'viewer1', role: 'viewer' });
 
     expect(projectServiceMock.removeProjectMember).toHaveBeenCalledWith('viewer1');
+  });
+
+  it('includes pending invitations in the members table data', () => {
+    expect(component.membersDataSource.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ memberId: 'pending@example.com', kind: 'invitation', status: 'pending' }),
+      ]),
+    );
+  });
+
+  it('cancels a pending invitation when confirmed', () => {
+    dialogMock.open.mockReturnValue({
+      afterClosed: () => of(true),
+    });
+
+    component.removeMember({
+      kind: 'invitation',
+      memberId: 'pending@example.com',
+      email: 'pending@example.com',
+      invitationId: 'invite-1',
+      role: 'viewer',
+      status: 'pending',
+    });
+
+    expect(projectServiceMock.revokeProjectInvitation).toHaveBeenCalledWith('invite-1');
   });
 });

--- a/frontend/src/app/components/project-settings/project-settings.component.ts
+++ b/frontend/src/app/components/project-settings/project-settings.component.ts
@@ -11,6 +11,7 @@ import { MatButton } from '@angular/material/button';
 import { DatePipe } from '@angular/common';
 import { ProjectRoles } from 'src/app/models/projectSettings.model';
 import { AddProjectMemberDialogComponent, AddProjectMemberDialogResponse } from '../add-project-member-dialog/add-project-member-dialog.component';
+import { AuthService } from 'src/app/auth/auth.service';
 
 interface MemberEntry {
   memberId: string;
@@ -36,13 +37,14 @@ interface ApiKeyEntry {
     imports: [MatList, MatListItem, MatButton, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, DatePipe]
 })
 export class ProjectSettingsComponent {
-  membersDisplayedColumns = ['memberId', 'role'];
+  membersDisplayedColumns = ['memberId', 'role', 'action'];
   membersDataSource: MatTableDataSource<MemberEntry>;
   apiKeysDisplayedColumns = ['keyId', 'createdAt', 'lastUsed', 'action'];
   apiKeysDataSource: MatTableDataSource<ApiKeyEntry>;
   private firebaseDataService = inject(FirebaseDataService);
   public dialog = inject(MatDialog);
   private projectService = inject(ProjectService);
+  private authService = inject(AuthService);
 
   get projectId() { return this.firebaseDataService.projectId(); }
   projectPath: string;
@@ -100,6 +102,50 @@ export class ProjectSettingsComponent {
         email: response.email,
         role: response.role,
       }).catch(console.error);
+    });
+  }
+
+  private get currentUserId(): string {
+    return this.authService.currentUser()?.uid || '';
+  }
+
+  private get currentUserProjectRole(): ProjectRoles | null {
+    return this.projectSettings?.members?.[this.currentUserId] || null;
+  }
+
+  canManageMembers(): boolean {
+    return this.currentUserProjectRole === 'owner' || this.currentUserProjectRole === 'admin';
+  }
+
+  canRemoveMember(member: MemberEntry): boolean {
+    if (!this.canManageMembers()) return false;
+    if (member.memberId === this.currentUserId) return false;
+    if (this.currentUserProjectRole === 'admin' && member.role === 'owner') return false;
+    return true;
+  }
+
+  canSetRole(member: MemberEntry, nextRole: ProjectRoles): boolean {
+    if (!this.canManageMembers()) return false;
+    if (member.role === nextRole) return false;
+    if (member.memberId === this.currentUserId) return false;
+    if (this.currentUserProjectRole === 'admin' && (member.role === 'owner' || nextRole === 'owner')) {
+      return false;
+    }
+    return true;
+  }
+
+  setMemberRole(member: MemberEntry, role: ProjectRoles) {
+    if (!this.canSetRole(member, role)) return;
+    this.projectService.updateProjectMemberRole({ memberId: member.memberId, role }).catch(console.error);
+  }
+
+  removeMember(member: MemberEntry) {
+    if (!this.canRemoveMember(member)) return;
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent);
+    dialogRef.afterClosed().subscribe((response) => {
+      if (response) {
+        this.projectService.removeProjectMember(member.memberId).catch(console.error);
+      }
     });
   }
 }

--- a/frontend/src/app/components/project-settings/project-settings.component.ts
+++ b/frontend/src/app/components/project-settings/project-settings.component.ts
@@ -12,6 +12,8 @@ import { DatePipe } from '@angular/common';
 import { ProjectRoles } from 'src/app/models/projectSettings.model';
 import { AddProjectMemberDialogComponent, AddProjectMemberDialogResponse } from '../add-project-member-dialog/add-project-member-dialog.component';
 import { AuthService } from 'src/app/auth/auth.service';
+import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatIcon } from '@angular/material/icon';
 
 interface MemberEntry {
   memberId: string;
@@ -32,12 +34,43 @@ interface ApiKeyEntry {
           .mat-column-keyId {
             flex: 0 0 60%;
           }
+
+          .member-role-cell {
+            align-items: center;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+          }
+
+          .member-role-chip {
+            align-items: center;
+            border: 1px solid var(--mat-sys-outline, rgba(0, 0, 0, 0.12));
+            border-radius: 999px;
+            display: inline-flex;
+            gap: 4px;
+            line-height: 1;
+            min-height: 32px;
+            padding-inline: 12px 8px;
+            text-transform: capitalize;
+          }
+
+          .member-role-chip.is-static {
+            cursor: default;
+          }
+
+          .member-role-chip mat-icon {
+            font-size: 18px;
+            height: 18px;
+            margin-right: -2px;
+            width: 18px;
+          }
         `,
     ],
-    imports: [MatList, MatListItem, MatButton, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, DatePipe]
+    imports: [MatList, MatListItem, MatButton, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, DatePipe, MatMenuTrigger, MatMenu, MatMenuItem, MatIcon]
 })
 export class ProjectSettingsComponent {
   membersDisplayedColumns = ['memberId', 'role', 'action'];
+  readonly assignableRoles: ProjectRoles[] = ['owner', 'admin', 'viewer'];
   membersDataSource: MatTableDataSource<MemberEntry>;
   apiKeysDisplayedColumns = ['keyId', 'createdAt', 'lastUsed', 'action'];
   apiKeysDataSource: MatTableDataSource<ApiKeyEntry>;
@@ -132,6 +165,10 @@ export class ProjectSettingsComponent {
       return false;
     }
     return true;
+  }
+
+  availableRoles(member: MemberEntry): ProjectRoles[] {
+    return this.assignableRoles.filter((role) => this.canSetRole(member, role));
   }
 
   setMemberRole(member: MemberEntry, role: ProjectRoles) {

--- a/frontend/src/app/components/project-settings/project-settings.component.ts
+++ b/frontend/src/app/components/project-settings/project-settings.component.ts
@@ -2,7 +2,7 @@ import { Component, inject, effect } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
 import { ProjectSettings } from 'src/app/models/projectSettings.model';
-import { FirebaseDataService } from 'src/app/services/firebase-data.service';
+import { FirebaseDataService, ProjectInvitationRecord } from 'src/app/services/firebase-data.service';
 import { ProjectService } from 'src/app/services/project.service';
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
 import { CreateKeyDialogComponent } from '../create-key-dialog/create-key-dialog.component';
@@ -14,10 +14,16 @@ import { AddProjectMemberDialogComponent, AddProjectMemberDialogResponse } from 
 import { AuthService } from 'src/app/auth/auth.service';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { MatIcon } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ApiService } from 'src/app/services/api.service';
 
 interface MemberEntry {
+  kind: 'member' | 'invitation';
   memberId: string;
   role: ProjectRoles;
+  invitationId?: string;
+  email?: string;
+  status?: 'pending';
 }
 
 interface ApiKeyEntry {
@@ -64,6 +70,17 @@ interface ApiKeyEntry {
             margin-right: -2px;
             width: 18px;
           }
+
+          .pending-chip {
+            border: 1px solid var(--mat-sys-outline, rgba(0, 0, 0, 0.12));
+            border-radius: 999px;
+            display: inline-flex;
+            font-size: 12px;
+            line-height: 1;
+            margin-left: 8px;
+            padding: 4px 8px;
+            text-transform: uppercase;
+          }
         `,
     ],
     imports: [MatList, MatListItem, MatButton, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, DatePipe, MatMenuTrigger, MatMenu, MatMenuItem, MatIcon]
@@ -78,25 +95,31 @@ export class ProjectSettingsComponent {
   public dialog = inject(MatDialog);
   private projectService = inject(ProjectService);
   private authService = inject(AuthService);
+  private snackBar = inject(MatSnackBar);
+  private apiService = inject(ApiService);
 
   get projectId() { return this.firebaseDataService.projectId(); }
   projectPath: string;
   projectSettings: ProjectSettings;
+  memberEmails: Record<string, string> = {};
 
   constructor() {
     effect(() => {
       const settings = this.firebaseDataService.projectSettings();
       this.projectPath = `/projects/${this.projectId}`;
+
       if (settings) {
         this.projectSettings = settings;
-        
-        // Transform members object to table data
-        const memberTableData = Object.keys(settings.members || {}).map((key) => {
-          return { memberId: key, role: settings.members[key] };
-        });
-        this.membersDataSource = new MatTableDataSource(memberTableData);
+        this.updateMembersTable();
 
-        // Transform apiKeys object to table data
+        if (this.projectId) {
+          this.apiService.listProjectMembers(this.projectId).then(members => {
+            this.memberEmails = {};
+            members.forEach(m => this.memberEmails[m.memberId] = m.email || m.displayName);
+            this.updateMembersTable();
+          }).catch(() => {});  // non-critical, fall back to uid display
+        }
+
         const apiKeysData = Object.keys(settings.apiKeys ? settings.apiKeys : {})
           .map((key) => {
             return { 
@@ -116,6 +139,25 @@ export class ProjectSettingsComponent {
   createApiKey() {
     this.dialog.open(CreateKeyDialogComponent);
   }
+
+  updateMembersTable() {
+    if (!this.projectSettings) return;
+    const settings = this.projectSettings;
+    const memberTableData = Object.keys(settings.members || {}).map((key) => {
+      return { kind: 'member' as const, memberId: key, email: this.memberEmails[key], role: settings.members![key] };
+    });
+    const pendingInvitationRows = this.firebaseDataService.projectInvitations()
+      .filter((invitation) => invitation?.status === 'pending')
+      .map((invitation: ProjectInvitationRecord) => ({
+        kind: 'invitation' as const,
+        memberId: invitation.email,
+        email: invitation.email,
+        invitationId: invitation.id,
+        role: invitation.role as ProjectRoles,
+        status: 'pending' as const,
+      }));
+    this.membersDataSource = new MatTableDataSource([...memberTableData, ...pendingInvitationRows]);
+  }
   revokeApiKey(keyId: string) {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent);
     dialogRef.afterClosed().subscribe((response) => {
@@ -134,7 +176,33 @@ export class ProjectSettingsComponent {
       this.projectService.inviteProjectMember({
         email: response.email,
         role: response.role,
-      }).catch(console.error);
+      })
+        .then(async (inviteResponse) => {
+          const emailLink = inviteResponse.firebaseEmailLink;
+          if (!emailLink && inviteResponse.existingUser) {
+            this.snackBar.open('Invitation created. User can accept in app.', 'Close', { duration: 4000 });
+            return;
+          }
+
+          if (!emailLink) {
+            this.snackBar.open('Invitation created. Email setup unavailable.', 'Close', { duration: 4000 });
+            return;
+          }
+
+          await this.authService.sendInvitationEmailLink(emailLink.email, emailLink.continueUrl);
+          this.snackBar.open(
+            inviteResponse.existingUser
+              ? 'Invitation created. Email sent and user can accept in app.'
+              : 'Invitation email sent.',
+            'Close',
+            { duration: 4000 },
+          );
+        })
+        .catch((error) => {
+          console.error(error);
+          const message = error instanceof Error ? error.message : 'Failed to create invitation';
+          this.snackBar.open(message, 'Close', { duration: 4000 });
+        });
     });
   }
 
@@ -152,12 +220,14 @@ export class ProjectSettingsComponent {
 
   canRemoveMember(member: MemberEntry): boolean {
     if (!this.canManageMembers()) return false;
+    if (member.kind === 'invitation') return true;
     if (member.memberId === this.currentUserId) return false;
     if (this.currentUserProjectRole === 'admin' && member.role === 'owner') return false;
     return true;
   }
 
   canSetRole(member: MemberEntry, nextRole: ProjectRoles): boolean {
+    if (member.kind === 'invitation') return false;
     if (!this.canManageMembers()) return false;
     if (member.role === nextRole) return false;
     if (member.memberId === this.currentUserId) return false;
@@ -181,7 +251,10 @@ export class ProjectSettingsComponent {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent);
     dialogRef.afterClosed().subscribe((response) => {
       if (response) {
-        this.projectService.removeProjectMember(member.memberId).catch(console.error);
+        const removal = member.kind === 'invitation' && member.invitationId
+          ? this.projectService.revokeProjectInvitation(member.invitationId)
+          : this.projectService.removeProjectMember(member.memberId);
+        removal.catch(console.error);
       }
     });
   }

--- a/frontend/src/app/components/project-settings/project-settings.component.ts
+++ b/frontend/src/app/components/project-settings/project-settings.component.ts
@@ -10,6 +10,7 @@ import { MatList, MatListItem } from '@angular/material/list';
 import { MatButton } from '@angular/material/button';
 import { DatePipe } from '@angular/common';
 import { ProjectRoles } from 'src/app/models/projectSettings.model';
+import { AddProjectMemberDialogComponent, AddProjectMemberDialogResponse } from '../add-project-member-dialog/add-project-member-dialog.component';
 
 interface MemberEntry {
   memberId: string;
@@ -86,6 +87,19 @@ export class ProjectSettingsComponent {
       if (response) {
         this.projectService.revokeApiKey(keyId);
       }
+    });
+  }
+
+  inviteMember() {
+    const dialogRef = this.dialog.open(AddProjectMemberDialogComponent);
+    dialogRef.afterClosed().subscribe((response: AddProjectMemberDialogResponse | undefined) => {
+      if (!response?.email) {
+        return;
+      }
+      this.projectService.inviteProjectMember({
+        email: response.email,
+        role: response.role,
+      }).catch(console.error);
     });
   }
 }

--- a/frontend/src/app/components/user-profile/user-profile.component.html
+++ b/frontend/src/app/components/user-profile/user-profile.component.html
@@ -32,6 +32,9 @@
       @if (!authService.currentUser()?.email) {
         <div class="email-linking">
           <p>Add and verify an email address so invitations can be matched to your account.</p>
+          @if (requiresEmailForLinkCompletion) {
+            <p>Verification link opened without saved session state. Enter the same email address to complete linking.</p>
+          }
           <mat-form-field>
             <mat-label>Email address</mat-label>
             <input matInput
@@ -51,6 +54,13 @@
                   (click)="sendEmailLink()">
             {{ isSendingEmailLink ? 'Sending...' : 'Send verification link' }}
           </button>
+          @if (hasEmailLinkCallback) {
+            <button mat-stroked-button
+                    [disabled]="isCompletingEmailLink"
+                    (click)="completeEmailLinkFromInput()">
+              {{ isCompletingEmailLink ? 'Completing...' : 'Complete verification' }}
+            </button>
+          }
         </div>
       }
       

--- a/frontend/src/app/components/user-profile/user-profile.component.html
+++ b/frontend/src/app/components/user-profile/user-profile.component.html
@@ -20,10 +20,37 @@
         </button>
       </div>
       
-      @if (authService.currentUser()?.email) {
-        <div class="detail-item">
-          <strong>Email:</strong>
+      <div class="detail-item">
+        <strong>Email:</strong>
+        @if (authService.currentUser()?.email) {
           <span>{{authService.currentUser()?.email}}</span>
+        } @else {
+          <span>Not available from sign-in provider</span>
+        }
+      </div>
+
+      @if (!authService.currentUser()?.email) {
+        <div class="email-linking">
+          <p>Add and verify an email address so invitations can be matched to your account.</p>
+          <mat-form-field>
+            <mat-label>Email address</mat-label>
+            <input matInput
+                   [(ngModel)]="emailInput"
+                   type="email"
+                   autocomplete="email"
+                   placeholder="name@example.com" />
+            @if (emailLinkError) {
+              <mat-error>{{ emailLinkError }}</mat-error>
+            }
+            @if (emailLinkSent) {
+              <mat-hint>Check your inbox and open the link while still signed in.</mat-hint>
+            }
+          </mat-form-field>
+          <button mat-flat-button
+                  [disabled]="isSendingEmailLink"
+                  (click)="sendEmailLink()">
+            {{ isSendingEmailLink ? 'Sending...' : 'Send verification link' }}
+          </button>
         </div>
       }
       

--- a/frontend/src/app/components/user-profile/user-profile.component.scss
+++ b/frontend/src/app/components/user-profile/user-profile.component.scss
@@ -37,3 +37,16 @@
 .user-id {
   font-family: monospace;
 }
+
+.email-linking {
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 420px;
+}
+
+.email-linking p {
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant);
+}

--- a/frontend/src/app/components/user-profile/user-profile.component.spec.ts
+++ b/frontend/src/app/components/user-profile/user-profile.component.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { signal } from '@angular/core';
 import { AuthService } from 'src/app/auth/auth.service';
 import { ApiService } from 'src/app/services/api.service';
 import { FirebaseDataService } from 'src/app/services/firebase-data.service';
@@ -11,6 +12,7 @@ import { UserProfileComponent } from './user-profile.component';
 describe('UserProfileComponent', () => {
   let component: UserProfileComponent;
   let fixture: ComponentFixture<UserProfileComponent>;
+  let authService: MockAuthService;
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
@@ -26,10 +28,30 @@ describe('UserProfileComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(UserProfileComponent);
     component = fixture.componentInstance;
+    authService = TestBed.inject(AuthService) as unknown as MockAuthService;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('shows missing-email guidance when provider has no email', () => {
+    authService.currentUser.set({ uid: 'no-email-user', providerData: [] } as any);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Not available from sign-in provider');
+    expect(fixture.nativeElement.textContent).toContain('Send verification link');
+  });
+
+  it('sends verification link from profile action', async () => {
+    authService.currentUser.set({ uid: 'no-email-user', providerData: [] } as any);
+    const sendSpy = vi.spyOn(authService, 'sendEmailLinkForCurrentUser').mockResolvedValue();
+    component.emailInput = 'person@example.com';
+
+    await component.sendEmailLink();
+
+    expect(sendSpy).toHaveBeenCalledWith('person@example.com');
+    expect(component.emailLinkSent).toBe(true);
   });
 });

--- a/frontend/src/app/components/user-profile/user-profile.component.spec.ts
+++ b/frontend/src/app/components/user-profile/user-profile.component.spec.ts
@@ -54,4 +54,24 @@ describe('UserProfileComponent', () => {
     expect(sendSpy).toHaveBeenCalledWith('person@example.com');
     expect(component.emailLinkSent).toBe(true);
   });
+
+  it('supports manual completion when callback has no pending email in storage', async () => {
+    vi.spyOn(authService, 'hasPendingEmailLinkInUrl').mockReturnValue(true);
+    vi.spyOn(authService, 'completePendingEmailLink')
+      .mockRejectedValueOnce({ code: 'auth/missing-email-for-link', message: 'Enter your email address to complete verification.' })
+      .mockResolvedValueOnce('linked');
+
+    fixture = TestBed.createComponent(UserProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.requiresEmailForLinkCompletion).toBe(true);
+
+    component.emailInput = 'person@example.com';
+    await component.completeEmailLinkFromInput();
+
+    expect(authService.completePendingEmailLink).toHaveBeenLastCalledWith('person@example.com');
+    expect(component.requiresEmailForLinkCompletion).toBe(false);
+  });
 });

--- a/frontend/src/app/components/user-profile/user-profile.component.ts
+++ b/frontend/src/app/components/user-profile/user-profile.component.ts
@@ -35,6 +35,9 @@ export class UserProfileComponent implements OnInit {
   emailLinkError = '';
   emailLinkSent = false;
   isSendingEmailLink = false;
+  hasEmailLinkCallback = false;
+  requiresEmailForLinkCompletion = false;
+  isCompletingEmailLink = false;
 
   private readonly USERNAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
   private readonly RESERVED = new Set([
@@ -47,15 +50,20 @@ export class UserProfileComponent implements OnInit {
     if (!user) return;
 
     this.emailInput = user.email || '';
+    this.hasEmailLinkCallback = this.authService.hasPendingEmailLinkInUrl();
 
     try {
       const linkResult = await this.authService.completePendingEmailLink();
       if (linkResult === 'linked') {
         this.emailLinkSent = false;
         this.emailLinkError = '';
+        this.requiresEmailForLinkCompletion = false;
         this.snackBar.open('Email linked successfully.', 'Close', { duration: 3000 });
       }
     } catch (error: any) {
+      if (error?.code === 'auth/missing-email-for-link') {
+        this.requiresEmailForLinkCompletion = true;
+      }
       this.emailLinkError = error?.message || 'Failed to complete email linking.';
     }
 
@@ -94,6 +102,28 @@ export class UserProfileComponent implements OnInit {
       this.emailLinkError = error?.message || 'Failed to send email verification link.';
     } finally {
       this.isSendingEmailLink = false;
+    }
+  }
+
+  async completeEmailLinkFromInput(): Promise<void> {
+    this.emailLinkError = '';
+
+    if (!this.emailInput.trim()) {
+      this.emailLinkError = 'Email is required';
+      return;
+    }
+
+    this.isCompletingEmailLink = true;
+    try {
+      const result = await this.authService.completePendingEmailLink(this.emailInput);
+      if (result === 'linked') {
+        this.requiresEmailForLinkCompletion = false;
+        this.snackBar.open('Email linked successfully.', 'Close', { duration: 3000 });
+      }
+    } catch (error: any) {
+      this.emailLinkError = error?.message || 'Failed to complete email linking.';
+    } finally {
+      this.isCompletingEmailLink = false;
     }
   }
 

--- a/frontend/src/app/components/user-profile/user-profile.component.ts
+++ b/frontend/src/app/components/user-profile/user-profile.component.ts
@@ -31,6 +31,10 @@ export class UserProfileComponent implements OnInit {
   usernameAvailable: boolean | null = null;
   usernameError = '';
   isSaving = false;
+  emailInput = '';
+  emailLinkError = '';
+  emailLinkSent = false;
+  isSendingEmailLink = false;
 
   private readonly USERNAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
   private readonly RESERVED = new Set([
@@ -42,6 +46,19 @@ export class UserProfileComponent implements OnInit {
     const user = this.authService.currentUser();
     if (!user) return;
 
+    this.emailInput = user.email || '';
+
+    try {
+      const linkResult = await this.authService.completePendingEmailLink();
+      if (linkResult === 'linked') {
+        this.emailLinkSent = false;
+        this.emailLinkError = '';
+        this.snackBar.open('Email linked successfully.', 'Close', { duration: 3000 });
+      }
+    } catch (error: any) {
+      this.emailLinkError = error?.message || 'Failed to complete email linking.';
+    }
+
     const snapshot = await this.firebaseDataService.getUserDocOnce(user.uid);
     const existing = snapshot['username'] as string | undefined;
     if (existing) {
@@ -50,13 +67,34 @@ export class UserProfileComponent implements OnInit {
     }
 
     // Pre-fill suggestion from GitHub provider or email prefix
-    const githubProvider = user.providerData.find(p => p.providerId === 'github.com');
+    const githubProvider = (user.providerData || []).find(p => p.providerId === 'github.com');
     const suggestion = githubProvider?.displayName
       ?? user.displayName
       ?? user.email?.split('@')[0]
       ?? '';
     this.usernameInput = suggestion.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '');
     await this.checkAvailability();
+  }
+
+  async sendEmailLink(): Promise<void> {
+    this.emailLinkError = '';
+    this.emailLinkSent = false;
+
+    if (!this.emailInput.trim()) {
+      this.emailLinkError = 'Email is required';
+      return;
+    }
+
+    this.isSendingEmailLink = true;
+    try {
+      await this.authService.sendEmailLinkForCurrentUser(this.emailInput);
+      this.emailLinkSent = true;
+      this.snackBar.open(`Verification link sent to ${this.emailInput}.`, 'Close', { duration: 4000 });
+    } catch (error: any) {
+      this.emailLinkError = error?.message || 'Failed to send email verification link.';
+    } finally {
+      this.isSendingEmailLink = false;
+    }
   }
 
   async checkAvailability(): Promise<void> {

--- a/frontend/src/app/guards/waitlist.guard.spec.ts
+++ b/frontend/src/app/guards/waitlist.guard.spec.ts
@@ -6,7 +6,7 @@ import { signal } from '@angular/core';
 import { waitlistGuard } from './waitlist.guard';
 import { AuthService } from '../auth/auth.service';
 
-const mockState: any = { url: '/dashboard' };
+let mockState: any = { url: '/dashboard' };
 
 function runGuard(): boolean | UrlTree {
   return TestBed.runInInjectionContext(() => waitlistGuard(null as any, mockState)) as boolean | UrlTree;
@@ -18,6 +18,7 @@ describe('waitlistGuard', () => {
   let userStatusSignal: ReturnType<typeof signal<string | null>>;
 
   beforeEach(() => {
+    mockState = { url: '/dashboard' };
     currentUserSignal = signal<any>({ uid: 'test-uid' });
     userStatusSignal = signal<string | null>('approved');
     routerSpy = {
@@ -58,5 +59,16 @@ describe('waitlistGuard', () => {
     const result = runGuard();
     expect(result).toBe(mockUrlTree);
     expect(routerSpy.parseUrl).toHaveBeenCalledWith('/waitlist');
+  });
+
+  it('allows /account/profile for pending users', () => {
+    mockState = { url: '/account/profile?emailLink=1' };
+    currentUserSignal.set({ uid: 'test-uid' });
+    userStatusSignal.set('pending');
+
+    const result = runGuard();
+
+    expect(result).toBe(true);
+    expect(routerSpy.parseUrl).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/guards/waitlist.guard.ts
+++ b/frontend/src/app/guards/waitlist.guard.ts
@@ -10,6 +10,9 @@ export const waitlistGuard: CanActivateFn = (_route, state) => {
     return router.createUrlTree(['/'], { queryParams: { returnUrl: state.url } });
   }
   if (authService.userStatus() === 'pending') {
+    if (state.url.startsWith('/account/profile')) {
+      return true;
+    }
     return router.parseUrl('/waitlist');
   }
   return true;

--- a/frontend/src/app/models/projectSettings.model.ts
+++ b/frontend/src/app/models/projectSettings.model.ts
@@ -9,6 +9,7 @@ export interface ApiKeyInfo {
 export interface ProjectSettings {
   name?: string;
   orgId?: string;
+  orgSlug?: string;
   visibility?: ProjectVisibility;
   members?: Record<string, ProjectRoles>;
   apiKeys?: Record<string, ApiKeyInfo>;

--- a/frontend/src/app/pages/accept-invite/accept-invite.component.spec.ts
+++ b/frontend/src/app/pages/accept-invite/accept-invite.component.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { AcceptInviteComponent } from './accept-invite.component';
+import { ApiService } from '../../services/api.service';
+
+describe('AcceptInviteComponent', () => {
+  let fixture: ComponentFixture<AcceptInviteComponent>;
+  let component: AcceptInviteComponent;
+  let apiServiceMock: { acceptProjectInvitation: ReturnType<typeof vi.fn> };
+  let routerMock: { navigate: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    apiServiceMock = { acceptProjectInvitation: vi.fn().mockResolvedValue({ accepted: true, orgId: "org1", projectId: "proj1" }) };
+
+    routerMock = { navigate: vi.fn().mockResolvedValue(true) };
+
+    await TestBed.configureTestingModule({
+      imports: [AcceptInviteComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: convertToParamMap({
+                orgId: 'org1',
+                projectId: 'proj1',
+                invitationId: 'invite-1',
+              }),
+            },
+          },
+        },
+        { provide: ApiService, useValue: apiServiceMock },
+        { provide: Router, useValue: routerMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AcceptInviteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('accepts invitation and redirects to project settings', async () => {
+    await Promise.resolve();
+
+    expect(apiServiceMock.acceptProjectInvitation).toHaveBeenCalledWith({
+      orgId: 'org1',
+      projectId: 'proj1',
+      invitationId: 'invite-1',
+    });
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/', 'org1', 'proj1', 'settings']);
+  });
+
+  it('shows missing parameters when query parameters are incomplete', async () => {
+    apiServiceMock.acceptProjectInvitation.mockClear();
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [AcceptInviteComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: convertToParamMap({ orgId: "org1" }),
+            },
+          },
+        },
+        { provide: ApiService, useValue: apiServiceMock },
+        { provide: Router, useValue: routerMock },
+      ],
+    }).compileComponents();
+
+    const missingFixture = TestBed.createComponent(AcceptInviteComponent);
+    const missingComponent = missingFixture.componentInstance;
+    missingFixture.detectChanges();
+
+    expect(missingComponent.statusMessage).toContain("Missing invitation parameters");
+    expect(apiServiceMock.acceptProjectInvitation).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/pages/accept-invite/accept-invite.component.spec.ts
+++ b/frontend/src/app/pages/accept-invite/accept-invite.component.spec.ts
@@ -3,17 +3,31 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { AcceptInviteComponent } from './accept-invite.component';
 import { ApiService } from '../../services/api.service';
+import { AuthService } from '../../auth/auth.service';
+import { signal } from '@angular/core';
 
 describe('AcceptInviteComponent', () => {
   let fixture: ComponentFixture<AcceptInviteComponent>;
   let component: AcceptInviteComponent;
   let apiServiceMock: { acceptProjectInvitation: ReturnType<typeof vi.fn> };
   let routerMock: { navigate: ReturnType<typeof vi.fn> };
+  let authServiceMock: {
+    currentUser: ReturnType<typeof signal<any>>;
+    hasPendingEmailLinkInUrl: ReturnType<typeof vi.fn>;
+    signInWithInvitationEmailLink: ReturnType<typeof vi.fn>;
+    logout: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
     apiServiceMock = { acceptProjectInvitation: vi.fn().mockResolvedValue({ accepted: true, orgId: "org1", projectId: "proj1" }) };
 
     routerMock = { navigate: vi.fn().mockResolvedValue(true) };
+    authServiceMock = {
+      currentUser: signal({ uid: 'user-1', email: 'invited@example.com' }),
+      hasPendingEmailLinkInUrl: vi.fn().mockReturnValue(false),
+      signInWithInvitationEmailLink: vi.fn().mockResolvedValue('signed-in'),
+      logout: vi.fn().mockResolvedValue(undefined),
+    };
 
     await TestBed.configureTestingModule({
       imports: [AcceptInviteComponent],
@@ -32,6 +46,7 @@ describe('AcceptInviteComponent', () => {
         },
         { provide: ApiService, useValue: apiServiceMock },
         { provide: Router, useValue: routerMock },
+        { provide: AuthService, useValue: authServiceMock },
       ],
     }).compileComponents();
 
@@ -67,6 +82,7 @@ describe('AcceptInviteComponent', () => {
         },
         { provide: ApiService, useValue: apiServiceMock },
         { provide: Router, useValue: routerMock },
+        { provide: AuthService, useValue: authServiceMock },
       ],
     }).compileComponents();
 
@@ -76,5 +92,77 @@ describe('AcceptInviteComponent', () => {
 
     expect(missingComponent.statusMessage).toContain("Missing invitation parameters");
     expect(apiServiceMock.acceptProjectInvitation).not.toHaveBeenCalled();
+  });
+
+  it('prompts for email when not signed in and opened from an email link', async () => {
+    apiServiceMock.acceptProjectInvitation.mockRejectedValue({ status: 401 });
+    authServiceMock.currentUser.set(null);
+    authServiceMock.hasPendingEmailLinkInUrl.mockReturnValue(true);
+
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [AcceptInviteComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: convertToParamMap({
+                orgId: 'org1',
+                projectId: 'proj1',
+                invitationId: 'invite-1',
+              }),
+            },
+          },
+        },
+        { provide: ApiService, useValue: apiServiceMock },
+        { provide: Router, useValue: routerMock },
+        { provide: AuthService, useValue: authServiceMock },
+      ],
+    }).compileComponents();
+
+    const promptFixture = TestBed.createComponent(AcceptInviteComponent);
+    const promptComponent = promptFixture.componentInstance;
+    promptFixture.detectChanges();
+    await Promise.resolve();
+
+    expect(promptComponent.showEmailPrompt).toBe(true);
+    expect(promptComponent.statusMessage).toContain('Enter the invited email');
+  });
+
+  it('shows mismatch guidance for the wrong signed-in email', async () => {
+    apiServiceMock.acceptProjectInvitation.mockRejectedValue({ status: 403 });
+    authServiceMock.currentUser.set({ uid: 'user-2', email: 'wrong@example.com' });
+    authServiceMock.hasPendingEmailLinkInUrl.mockReturnValue(true);
+
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [AcceptInviteComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: convertToParamMap({
+                orgId: 'org1',
+                projectId: 'proj1',
+                invitationId: 'invite-1',
+              }),
+            },
+          },
+        },
+        { provide: ApiService, useValue: apiServiceMock },
+        { provide: Router, useValue: routerMock },
+        { provide: AuthService, useValue: authServiceMock },
+      ],
+    }).compileComponents();
+
+    const mismatchFixture = TestBed.createComponent(AcceptInviteComponent);
+    const mismatchComponent = mismatchFixture.componentInstance;
+    mismatchFixture.detectChanges();
+    await Promise.resolve();
+
+    expect(mismatchComponent.statusMessage).toContain('different email');
+    expect(mismatchComponent.showSignOut).toBe(true);
   });
 });

--- a/frontend/src/app/pages/accept-invite/accept-invite.component.ts
+++ b/frontend/src/app/pages/accept-invite/accept-invite.component.ts
@@ -4,19 +4,38 @@ import { CommonModule } from '@angular/common';
 import { ApiService } from '../../services/api.service';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
+import { AuthService } from '../../auth/auth.service';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 
 @Component({
   selector: 'app-accept-invite',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule],
+  imports: [CommonModule, FormsModule, MatCardModule, MatButtonModule, MatFormFieldModule, MatInputModule],
   template: `
     <div class="accept-invite-page">
       <mat-card>
         <mat-card-title>Project Invitation</mat-card-title>
         <mat-card-content>
           <p>{{ statusMessage }}</p>
+          @if (showEmailPrompt) {
+            <mat-form-field>
+              <mat-label>Invited email</mat-label>
+              <input matInput [(ngModel)]="emailInput" type="email" />
+            </mat-form-field>
+          }
         </mat-card-content>
         <mat-card-actions>
+          @if (showAcceptButton) {
+            <button mat-flat-button color="primary" (click)="onAcceptClick()">Accept Invitation</button>
+          }
+          @if (showEmailPrompt) {
+            <button mat-flat-button (click)="completeEmailSignIn()">Continue</button>
+          }
+          @if (showSignOut) {
+            <button mat-button (click)="signOutAndRetry()">Use Invited Email</button>
+          }
           <button mat-flat-button (click)="goHome()">Go Home</button>
         </mat-card-actions>
       </mat-card>
@@ -38,27 +57,91 @@ export class AcceptInviteComponent {
   private route = inject(ActivatedRoute);
   private apiService = inject(ApiService);
   private router = inject(Router);
+  private authService = inject(AuthService);
 
-  statusMessage = 'Accepting invitation...';
+  private orgId = this.route.snapshot.queryParamMap.get('orgId');
+  private projectId = this.route.snapshot.queryParamMap.get('projectId');
+  private invitationId = this.route.snapshot.queryParamMap.get('invitationId');
+
+  statusMessage = '';
+  emailInput = '';
+  showEmailPrompt = false;
+  showSignOut = false;
+  showAcceptButton = false;
 
   constructor() {
-    const orgId = this.route.snapshot.queryParamMap.get('orgId');
-    const projectId = this.route.snapshot.queryParamMap.get('projectId');
-    const invitationId = this.route.snapshot.queryParamMap.get('invitationId');
-
-    if (!orgId || !projectId || !invitationId) {
+    if (!this.orgId || !this.projectId || !this.invitationId) {
       this.statusMessage = 'Missing invitation parameters.';
       return;
     }
 
-    this.apiService.acceptProjectInvitation({ orgId, projectId, invitationId })
-      .then(() => {
-        this.statusMessage = 'Invitation accepted. Redirecting to project settings...';
-        return this.router.navigate(['/', orgId, projectId, 'settings']);
-      })
-      .catch(() => {
-        this.statusMessage = 'Failed to accept invitation. Please try again.';
+    this.statusMessage = 'You have been invited to join this project.';
+    this.showAcceptButton = true;
+  }
+
+  async onAcceptClick() {
+    this.showAcceptButton = false;
+    this.statusMessage = 'Accepting invitation...';
+    await this.acceptInvitation();
+  }
+
+  async completeEmailSignIn() {
+    this.statusMessage = 'Signing in...';
+    try {
+      await this.authService.signInWithInvitationEmailLink(this.emailInput);
+      this.showEmailPrompt = false;
+      this.showSignOut = false;
+      await this.acceptInvitation();
+    } catch (error) {
+      console.error(error);
+      this.statusMessage = 'Could not sign in with that email link. Check the invited email and try again.';
+    }
+  }
+
+  async signOutAndRetry() {
+    await this.authService.logout();
+    this.showSignOut = false;
+    this.showEmailPrompt = this.authService.hasPendingEmailLinkInUrl();
+    this.statusMessage = this.showEmailPrompt
+      ? 'Enter the invited email to continue.'
+      : 'Sign in with the invited account to accept this invitation.';
+  }
+
+  private async acceptInvitation() {
+    if (!this.orgId || !this.projectId || !this.invitationId) {
+      return;
+    }
+
+    try {
+      await this.apiService.acceptProjectInvitation({
+        orgId: this.orgId,
+        projectId: this.projectId,
+        invitationId: this.invitationId,
       });
+      this.statusMessage = 'Invitation accepted. Redirecting to project settings...';
+      await this.router.navigate(['/', this.orgId, this.projectId, 'settings']);
+    } catch (error: any) {
+      const status = error?.status;
+      if (status === 401) {
+        this.showEmailPrompt = this.authService.hasPendingEmailLinkInUrl();
+        this.statusMessage = this.showEmailPrompt
+          ? 'Enter the invited email to continue.'
+          : 'Sign in with the invited account to accept this invitation.';
+        return;
+      }
+
+      if (status === 403) {
+        const currentEmail = this.authService.currentUser()?.email;
+        this.showSignOut = !!currentEmail && this.authService.hasPendingEmailLinkInUrl();
+        this.showEmailPrompt = false;
+        this.statusMessage = currentEmail
+          ? `This invite is for a different email than ${currentEmail}.`
+          : 'This invite is for a different email address.';
+        return;
+      }
+
+      this.statusMessage = error instanceof Error ? error.message : 'Failed to accept invitation. Please try again.';
+    }
   }
 
   goHome() {

--- a/frontend/src/app/pages/accept-invite/accept-invite.component.ts
+++ b/frontend/src/app/pages/accept-invite/accept-invite.component.ts
@@ -1,0 +1,67 @@
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { ApiService } from '../../services/api.service';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-accept-invite',
+  standalone: true,
+  imports: [CommonModule, MatCardModule, MatButtonModule],
+  template: `
+    <div class="accept-invite-page">
+      <mat-card>
+        <mat-card-title>Project Invitation</mat-card-title>
+        <mat-card-content>
+          <p>{{ statusMessage }}</p>
+        </mat-card-content>
+        <mat-card-actions>
+          <button mat-flat-button (click)="goHome()">Go Home</button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+  `,
+  styles: [
+    `
+      .accept-invite-page {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 60vh;
+        padding: 24px;
+      }
+    `,
+  ],
+})
+export class AcceptInviteComponent {
+  private route = inject(ActivatedRoute);
+  private apiService = inject(ApiService);
+  private router = inject(Router);
+
+  statusMessage = 'Accepting invitation...';
+
+  constructor() {
+    const orgId = this.route.snapshot.queryParamMap.get('orgId');
+    const projectId = this.route.snapshot.queryParamMap.get('projectId');
+    const invitationId = this.route.snapshot.queryParamMap.get('invitationId');
+
+    if (!orgId || !projectId || !invitationId) {
+      this.statusMessage = 'Missing invitation parameters.';
+      return;
+    }
+
+    this.apiService.acceptProjectInvitation({ orgId, projectId, invitationId })
+      .then(() => {
+        this.statusMessage = 'Invitation accepted. Redirecting to project settings...';
+        return this.router.navigate(['/', orgId, projectId, 'settings']);
+      })
+      .catch(() => {
+        this.statusMessage = 'Failed to accept invitation. Please try again.';
+      });
+  }
+
+  goHome() {
+    this.router.navigate(['/']).catch(console.error);
+  }
+}

--- a/frontend/src/app/pages/waitlist/waitlist.component.ts
+++ b/frontend/src/app/pages/waitlist/waitlist.component.ts
@@ -1,15 +1,19 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../auth/auth.service';
 import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
+import { FormsModule } from '@angular/forms';
+import { MatFormField, MatHint, MatError, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-waitlist',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatCardModule, MatIconModule],
+  imports: [CommonModule, FormsModule, MatButtonModule, MatCardModule, MatIconModule, MatFormField, MatLabel, MatInput, MatError, MatHint],
   template: `
     <div class="waitlist-page">
       <div class="top-bar">
@@ -30,9 +34,49 @@ import { MatIconModule } from '@angular/material/icon';
             <p>
               Thanks for signing up! To ensure a great experience for our early users, new accounts are currently subject to manual review.
             </p>
-            <p>
-              We will notify you at <strong>{{ authService.currentUser()?.email }}</strong> once your account has been approved.
-            </p>
+
+            @if (authService.currentUser()?.email) {
+              <p>
+                We will notify you at <strong>{{ authService.currentUser()?.email }}</strong> once your account has been approved.
+              </p>
+            } @else {
+              <p>
+                Add your email address now so invitations and approval notifications can reach you.
+              </p>
+              <div class="email-linking">
+                @if (requiresEmailForLinkCompletion) {
+                  <p>Verification link opened without saved session state. Enter the same email address to complete linking.</p>
+                }
+                <mat-form-field>
+                  <mat-label>Email address</mat-label>
+                  <input matInput
+                        [(ngModel)]="emailInput"
+                        type="email"
+                        autocomplete="email"
+                        placeholder="name@example.com" />
+                  @if (emailLinkError) {
+                    <mat-error>{{ emailLinkError }}</mat-error>
+                  }
+                  @if (emailLinkSent) {
+                    <mat-hint>Check your inbox and open the link while still signed in.</mat-hint>
+                  }
+                </mat-form-field>
+                <div class="email-actions">
+                  <button mat-flat-button
+                          [disabled]="isSendingEmailLink"
+                          (click)="sendEmailLink()">
+                    {{ isSendingEmailLink ? 'Sending...' : 'Send verification link' }}
+                  </button>
+                  @if (hasEmailLinkCallback) {
+                    <button mat-stroked-button
+                            [disabled]="isCompletingEmailLink"
+                            (click)="completeEmailLinkFromInput()">
+                      {{ isCompletingEmailLink ? 'Completing...' : 'Complete verification' }}
+                    </button>
+                  }
+                </div>
+              </div>
+            }
           </mat-card-content>
           
           <mat-card-actions class="card-actions">
@@ -95,11 +139,102 @@ import { MatIconModule } from '@angular/material/icon';
       justify-content: flex-end;
       padding: 16px 0 0 0;
     }
+
+    .email-linking {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .email-linking p {
+      margin: 0;
+    }
+
+    .email-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
   `]
 })
-export class WaitlistComponent {
+export class WaitlistComponent implements OnInit {
   authService = inject(AuthService);
   router = inject(Router);
+  snackBar = inject(MatSnackBar);
+
+  emailInput = '';
+  emailLinkError = '';
+  emailLinkSent = false;
+  isSendingEmailLink = false;
+  hasEmailLinkCallback = false;
+  requiresEmailForLinkCompletion = false;
+  isCompletingEmailLink = false;
+
+  async ngOnInit(): Promise<void> {
+    const user = this.authService.currentUser();
+    if (!user) return;
+
+    this.emailInput = user.email || '';
+    this.hasEmailLinkCallback = this.authService.hasPendingEmailLinkInUrl();
+
+    try {
+      const result = await this.authService.completePendingEmailLink();
+      if (result === 'linked') {
+        this.emailLinkError = '';
+        this.requiresEmailForLinkCompletion = false;
+        this.snackBar.open('Email linked successfully.', 'Close', { duration: 3000 });
+      }
+    } catch (error: any) {
+      if (error?.code === 'auth/missing-email-for-link') {
+        this.requiresEmailForLinkCompletion = true;
+      }
+      this.emailLinkError = error?.message || 'Failed to complete email linking.';
+    }
+  }
+
+  async sendEmailLink(): Promise<void> {
+    this.emailLinkError = '';
+    this.emailLinkSent = false;
+
+    if (!this.emailInput.trim()) {
+      this.emailLinkError = 'Email is required';
+      return;
+    }
+
+    this.isSendingEmailLink = true;
+    try {
+      await this.authService.sendEmailLinkForCurrentUser(this.emailInput);
+      this.emailLinkSent = true;
+      this.snackBar.open(`Verification link sent to ${this.emailInput}.`, 'Close', { duration: 4000 });
+    } catch (error: any) {
+      this.emailLinkError = error?.message || 'Failed to send email verification link.';
+    } finally {
+      this.isSendingEmailLink = false;
+    }
+  }
+
+  async completeEmailLinkFromInput(): Promise<void> {
+    this.emailLinkError = '';
+
+    if (!this.emailInput.trim()) {
+      this.emailLinkError = 'Email is required';
+      return;
+    }
+
+    this.isCompletingEmailLink = true;
+    try {
+      const result = await this.authService.completePendingEmailLink(this.emailInput);
+      if (result === 'linked') {
+        this.requiresEmailForLinkCompletion = false;
+        this.snackBar.open('Email linked successfully.', 'Close', { duration: 3000 });
+      }
+    } catch (error: any) {
+      this.emailLinkError = error?.message || 'Failed to complete email linking.';
+    } finally {
+      this.isCompletingEmailLink = false;
+    }
+  }
 
   async signOut() {
     await this.authService.logout();

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -62,6 +62,17 @@ export interface AcceptProjectInvitationResponse {
   projectId: string;
 }
 
+export interface UpdateProjectMemberRoleRequest {
+  projectId: string;
+  memberId: string;
+  role: ProjectRoles;
+}
+
+export interface RemoveProjectMemberRequest {
+  projectId: string;
+  memberId: string;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -229,6 +240,49 @@ export class ApiService {
 
     if (!response) {
       throw new Error('Empty response from project invitation acceptance endpoint');
+    }
+
+    return response;
+  }
+
+  async updateProjectMemberRole(request: UpdateProjectMemberRoleRequest): Promise<{ memberId: string; role: ProjectRoles }> {
+    const [orgId, projectId] = request.projectId.split('/');
+    if (!orgId || !projectId || request.projectId.split('/').length !== 2) {
+      throw new Error(`Invalid projectId format '${request.projectId}': expected 'orgSlug/projectSlug'`);
+    }
+
+    const apiUrl = await this.getApiUrl();
+    const headers = await this.buildMcpHeaders(request.projectId);
+
+    const response = await this.http.patch<{ memberId: string; role: ProjectRoles }>(
+      `${apiUrl}/api/orgs/${orgId}/projects/${projectId}/members/${request.memberId}`,
+      { role: request.role },
+      { headers },
+    ).toPromise();
+
+    if (!response) {
+      throw new Error('Empty response from project member role update endpoint');
+    }
+
+    return response;
+  }
+
+  async removeProjectMember(request: RemoveProjectMemberRequest): Promise<{ removed: string }> {
+    const [orgId, projectId] = request.projectId.split('/');
+    if (!orgId || !projectId || request.projectId.split('/').length !== 2) {
+      throw new Error(`Invalid projectId format '${request.projectId}': expected 'orgSlug/projectSlug'`);
+    }
+
+    const apiUrl = await this.getApiUrl();
+    const headers = await this.buildMcpHeaders(request.projectId);
+
+    const response = await this.http.delete<{ removed: string }>(
+      `${apiUrl}/api/orgs/${orgId}/projects/${projectId}/members/${request.memberId}`,
+      { headers },
+    ).toPromise();
+
+    if (!response) {
+      throw new Error('Empty response from project member removal endpoint');
     }
 
     return response;

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -1,3 +1,4 @@
+import { ProjectRoles } from "../models/projectSettings.model";
 import { HttpClient, HttpHeaders, HttpEvent, HttpEventType } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, of } from 'rxjs';
@@ -34,6 +35,19 @@ export interface CreateApiKeyResponse {
 export interface UploadDataResponse {
   uploadUrl: string;
   filePath: string;
+}
+
+export interface InviteProjectMemberRequest {
+  projectId: string;
+  email: string;
+  role: ProjectRoles;
+}
+
+export interface InviteProjectMemberResponse {
+  invitationId: string;
+  email: string;
+  status: 'pending' | 'accepted';
+  existingUser: boolean;
 }
 
 @Injectable({
@@ -163,6 +177,31 @@ export class ApiService {
       createdAt: result.createdAt,
       message: result.message
     };
+  }
+
+  async inviteProjectMember(request: InviteProjectMemberRequest): Promise<InviteProjectMemberResponse> {
+    const [orgId, projectId] = request.projectId.split('/');
+    if (!orgId || !projectId || request.projectId.split('/').length !== 2) {
+      throw new Error(`Invalid projectId format '${request.projectId}': expected 'orgSlug/projectSlug'`);
+    }
+
+    const apiUrl = await this.getApiUrl();
+    const headers = await this.buildMcpHeaders(request.projectId);
+
+    const response = await this.http.post<InviteProjectMemberResponse>(
+      `${apiUrl}/api/orgs/${orgId}/projects/${projectId}/invitations`,
+      {
+        email: request.email,
+        role: request.role,
+      },
+      { headers },
+    ).toPromise();
+
+    if (!response) {
+      throw new Error('Empty response from project invitation endpoint');
+    }
+
+    return response;
   }
 
 

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -50,6 +50,18 @@ export interface InviteProjectMemberResponse {
   existingUser: boolean;
 }
 
+export interface AcceptProjectInvitationRequest {
+  orgId: string;
+  projectId: string;
+  invitationId: string;
+}
+
+export interface AcceptProjectInvitationResponse {
+  accepted: boolean;
+  orgId: string;
+  projectId: string;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -199,6 +211,24 @@ export class ApiService {
 
     if (!response) {
       throw new Error('Empty response from project invitation endpoint');
+    }
+
+    return response;
+  }
+
+  async acceptProjectInvitation(request: AcceptProjectInvitationRequest): Promise<AcceptProjectInvitationResponse> {
+    const fullProjectId = `${request.orgId}/${request.projectId}`;
+    const apiUrl = await this.getApiUrl();
+    const headers = await this.buildMcpHeaders(fullProjectId);
+
+    const response = await this.http.post<AcceptProjectInvitationResponse>(
+      `${apiUrl}/api/orgs/${request.orgId}/projects/${request.projectId}/invitations/${request.invitationId}/accept`,
+      {},
+      { headers },
+    ).toPromise();
+
+    if (!response) {
+      throw new Error('Empty response from project invitation acceptance endpoint');
     }
 
     return response;

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -1,5 +1,5 @@
 import { ProjectRoles } from "../models/projectSettings.model";
-import { HttpClient, HttpHeaders, HttpEvent, HttpEventType } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpEvent, HttpEventType, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { map, shareReplay, catchError } from 'rxjs/operators';
@@ -48,6 +48,12 @@ export interface InviteProjectMemberResponse {
   email: string;
   status: 'pending' | 'accepted';
   existingUser: boolean;
+  requiresEmailBootstrap?: boolean;
+  firebaseEmailLink?: {
+    email: string;
+    continueUrl: string;
+    handleCodeInApp: boolean;
+  };
 }
 
 export interface AcceptProjectInvitationRequest {
@@ -93,6 +99,18 @@ export class ApiService {
       throw new Error(errorText);
     }
     return response.result?.structuredContent || response.result;
+  }
+
+  private rethrowHttpError(error: unknown): never {
+    if (error instanceof HttpErrorResponse) {
+      const serverMessage = typeof error.error === 'string'
+        ? error.error.trim()
+        : error.error?.message;
+      const parsedError = new Error(serverMessage || error.message || `HTTP ${error.status}`);
+      (parsedError as any).status = error.status;
+      throw parsedError;
+    }
+    throw error;
   }
 
   private async buildMcpHeaders(projectId?: string): Promise<HttpHeaders> {
@@ -218,7 +236,7 @@ export class ApiService {
         role: request.role,
       },
       { headers },
-    ).toPromise();
+    ).toPromise().catch((error) => this.rethrowHttpError(error));
 
     if (!response) {
       throw new Error('Empty response from project invitation endpoint');
@@ -236,7 +254,7 @@ export class ApiService {
       `${apiUrl}/api/orgs/${request.orgId}/projects/${request.projectId}/invitations/${request.invitationId}/accept`,
       {},
       { headers },
-    ).toPromise();
+    ).toPromise().catch((error) => this.rethrowHttpError(error));
 
     if (!response) {
       throw new Error('Empty response from project invitation acceptance endpoint');
@@ -258,7 +276,7 @@ export class ApiService {
       `${apiUrl}/api/orgs/${orgId}/projects/${projectId}/members/${request.memberId}`,
       { role: request.role },
       { headers },
-    ).toPromise();
+    ).toPromise().catch((error) => this.rethrowHttpError(error));
 
     if (!response) {
       throw new Error('Empty response from project member role update endpoint');
@@ -279,7 +297,7 @@ export class ApiService {
     const response = await this.http.delete<{ removed: string }>(
       `${apiUrl}/api/orgs/${orgId}/projects/${projectId}/members/${request.memberId}`,
       { headers },
-    ).toPromise();
+    ).toPromise().catch((error) => this.rethrowHttpError(error));
 
     if (!response) {
       throw new Error('Empty response from project member removal endpoint');
@@ -288,6 +306,31 @@ export class ApiService {
     return response;
   }
 
+  async listProjectMembers(projectId: string): Promise<{ memberId: string; email: string; displayName: string; role: ProjectRoles }[]> {    const [orgId, projectSlug] = projectId.split('/');
+    if (!orgId || !projectSlug) throw new Error(`Invalid projectId format: ${projectId}`);
+
+    const apiUrl = await this.getApiUrl();
+    const headers = await this.buildMcpHeaders(projectId);
+
+    return this.http.get<{ memberId: string; email: string; displayName: string; role: ProjectRoles }[]>(
+      `${apiUrl}/api/orgs/${orgId}/projects/${projectSlug}/members`,
+      { headers },
+    ).toPromise().catch((error) => this.rethrowHttpError(error)) as Promise<any>;
+  }
+
+  async markNotificationRead(notificationId: string): Promise<void> {
+    const apiUrl = await this.getApiUrl();
+    const headers = await this.buildMcpHeaders();
+    await this.http.patch(`${apiUrl}/api/notifications/${notificationId}`, {}, { headers })
+      .toPromise().catch((error) => this.rethrowHttpError(error));
+  }
+
+  async deleteNotification(notificationId: string): Promise<void> {
+    const apiUrl = await this.getApiUrl();
+    const headers = await this.buildMcpHeaders();
+    await this.http.delete(`${apiUrl}/api/notifications/${notificationId}`, { headers })
+      .toPromise().catch((error) => this.rethrowHttpError(error));
+  }
 
   async uploadFileToPath(
     path: string,

--- a/frontend/src/app/services/firebase-data.service.ts
+++ b/frontend/src/app/services/firebase-data.service.ts
@@ -87,6 +87,7 @@ export class FirebaseDataService {
   private agentsSignal = signal<Agent[]>([]);
   private machinesSignal = signal<Machine[]>([]);
   private userProjectsSignal = signal<Project[]>([]);
+  private notificationsSignal = signal<DocumentData[]>([]);
 
   // Project settings signal
   private projectSettingsSignal = signal<ProjectSettings | null>(null);
@@ -102,6 +103,7 @@ export class FirebaseDataService {
   private machinesObservable$: Observable<unknown[]>;
   public userProjectsObservable$: Observable<Project[]>; // Made public for ProjectService
   private projectSettingsObservable$: Observable<unknown>;
+  private notificationsObservable$: Observable<unknown[]>;
 
   constructor() {
     this.firestore = getFirestore();
@@ -238,6 +240,17 @@ export class FirebaseDataService {
       })
     );
 
+    this.notificationsObservable$ = toObservable(this.authService.currentUser).pipe(
+      switchMap((user) => {
+        if (!user?.uid) return of([]);
+        return runInInjectionContext(this.injector, () => {
+          const notificationsCollection = collection(this.firestore, `users/${user.uid}/notifications`);
+          const notificationsQuery = query(notificationsCollection, orderBy('createdAt', 'desc'));
+          return this.collectionData(notificationsQuery);
+        });
+      })
+    );
+
     this.projectSettingsObservable$ = projectWithAuth$.pipe(
       switchMap(([projectId, user]) => {
         if (!projectId || !user) return of(null);
@@ -288,6 +301,10 @@ export class FirebaseDataService {
     this.userProjectsObservable$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data) => this.userProjectsSignal.set((data as Project[]) || []));
+
+    this.notificationsObservable$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data) => this.notificationsSignal.set((data as DocumentData[]) || []));
 
     this.projectSettingsObservable$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -366,6 +383,10 @@ export class FirebaseDataService {
 
   get userProjects() {
     return this.userProjectsSignal.asReadonly();
+  }
+
+  get notifications() {
+    return this.notificationsSignal.asReadonly();
   }
 
   get userProjectsObservable() {

--- a/frontend/src/app/services/firebase-data.service.ts
+++ b/frontend/src/app/services/firebase-data.service.ts
@@ -55,6 +55,15 @@ import { ProjectSettings } from '../models/projectSettings.model';
 import { ApiService } from './api.service';
 import { AuthService } from '../auth/auth.service';
 
+export interface ProjectInvitationRecord extends DocumentData {
+  id: string;
+  email: string;
+  role: string;
+  status: string;
+  createdAt?: number;
+  expiresAt?: number;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -88,6 +97,7 @@ export class FirebaseDataService {
   private machinesSignal = signal<Machine[]>([]);
   private userProjectsSignal = signal<Project[]>([]);
   private notificationsSignal = signal<DocumentData[]>([]);
+  private projectInvitationsSignal = signal<ProjectInvitationRecord[]>([]);
 
   // Project settings signal
   private projectSettingsSignal = signal<ProjectSettings | null>(null);
@@ -104,6 +114,7 @@ export class FirebaseDataService {
   public userProjectsObservable$: Observable<Project[]>; // Made public for ProjectService
   private projectSettingsObservable$: Observable<unknown>;
   private notificationsObservable$: Observable<unknown[]>;
+  private projectInvitationsObservable$: Observable<unknown[]>;
 
   constructor() {
     this.firestore = getFirestore();
@@ -248,6 +259,10 @@ export class FirebaseDataService {
           const notificationsQuery = query(notificationsCollection, orderBy('createdAt', 'desc'));
           return this.collectionData(notificationsQuery);
         });
+      }),
+      catchError((error) => {
+        console.error('Error loading notifications:', error);
+        return of([]);
       })
     );
 
@@ -257,6 +272,17 @@ export class FirebaseDataService {
         return runInInjectionContext(this.injector, () =>
           this.docData(doc(this.firestore, `/${this.getProjectPath(projectId)}`))
         );
+      })
+    );
+
+    this.projectInvitationsObservable$ = projectWithAuth$.pipe(
+      switchMap(([projectId, user]) => {
+        if (!projectId || !user) return of([]);
+        return runInInjectionContext(this.injector, () => {
+          const invitationsCollection = collection(this.firestore, `/${this.getProjectPath(projectId)}/invitations`);
+          const invitationsQuery = query(invitationsCollection, orderBy('createdAt', 'desc'));
+          return this.collectionData(invitationsQuery);
+        });
       })
     );
 
@@ -309,6 +335,10 @@ export class FirebaseDataService {
     this.projectSettingsObservable$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data) => this.projectSettingsSignal.set(data as ProjectSettings | null));
+
+    this.projectInvitationsObservable$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data) => this.projectInvitationsSignal.set((data as ProjectInvitationRecord[]) || []));
   }
 
   // Public methods to set project and agent
@@ -397,6 +427,10 @@ export class FirebaseDataService {
     return this.projectSettingsSignal.asReadonly();
   }
 
+  get projectInvitations() {
+    return this.projectInvitationsSignal.asReadonly();
+  }
+
   get projectId() {
     return this.currentProjectId.asReadonly();
   }
@@ -456,6 +490,13 @@ export class FirebaseDataService {
   async deleteAction(projectId: string, id: string): Promise<void> {
     await runInInjectionContext(this.injector, async () => {
       const docRef = doc(this.firestore, `/${this.getProjectPath(projectId)}/actions/${id}`);
+      await deleteDoc(docRef);
+    });
+  }
+
+  async deleteProjectInvitation(projectId: string, invitationId: string): Promise<void> {
+    await runInInjectionContext(this.injector, async () => {
+      const docRef = doc(this.firestore, `/${this.getProjectPath(projectId)}/invitations/${invitationId}`);
       await deleteDoc(docRef);
     });
   }

--- a/frontend/src/app/services/organization.service.ts
+++ b/frontend/src/app/services/organization.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { AuthService } from '../auth/auth.service';
 import { ApiService } from './api.service';
 import { firstValueFrom } from 'rxjs';
-import { OrganizationDoc } from '../models/organization.model';
+import { OrganizationDoc, OrgMemberDoc } from '../models/organization.model';
 
 @Injectable({ providedIn: 'root' })
 export class OrganizationService {
@@ -33,7 +33,9 @@ export class OrganizationService {
 
   async createOrganization(name: string, slug?: string): Promise<OrganizationDoc> {
     const url = await this.apiService.getApiUrl();
-    const headers = await (this.apiService as any).buildMcpHeaders();
+    // Use type assertion since buildMcpHeaders is private/not in the interface
+    const getHeaders = (this.apiService as any).buildMcpHeaders ? (this.apiService as any).buildMcpHeaders.bind(this.apiService) : async () => new HttpHeaders();
+    const headers = await getHeaders();
     return firstValueFrom(
       this.http.post<OrganizationDoc>(
         `${url}/api/orgs`,
@@ -41,5 +43,25 @@ export class OrganizationService {
         { headers }
       )
     );
+  }
+
+  async getOrgMembers(orgId: string): Promise<OrgMemberDoc[]> {
+    const url = await this.apiService.getApiUrl();
+    const user = this.authService.currentUser();
+    if (!user) return [];
+    
+    try {
+      const idToken = await user.getIdToken();
+      const headers = new HttpHeaders()
+        .set('Authorization', `Bearer ${idToken}`)
+        .set('Accept', 'application/json');
+        
+      return await firstValueFrom(
+        this.http.get<OrgMemberDoc[]>(`${url}/api/orgs/${orgId}/members`, { headers })
+      );
+    } catch (e) {
+      console.warn('Failed to load org members', e);
+      return [];
+    }
   }
 }

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -78,4 +78,27 @@ export class ProjectService {
       role: request.role,
     });
   }
+
+  async updateProjectMemberRole(request: { memberId: string; role: ProjectRoles }) {
+    const projectId = this.currentProjectId;
+    if (!projectId) {
+      throw new Error('No project selected. Please select a project first.');
+    }
+    return this.apiService.updateProjectMemberRole({
+      projectId,
+      memberId: request.memberId,
+      role: request.role,
+    });
+  }
+
+  async removeProjectMember(memberId: string) {
+    const projectId = this.currentProjectId;
+    if (!projectId) {
+      throw new Error('No project selected. Please select a project first.');
+    }
+    return this.apiService.removeProjectMember({
+      projectId,
+      memberId,
+    });
+  }
 }

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -6,6 +6,7 @@ import { Project } from '../models/firebase.model';
 import { ServerService } from './server.service';
 import { ApiService } from './api.service';
 import { FirebaseDataService } from './firebase-data.service';
+import { ProjectRoles } from '../models/projectSettings.model';
 
 @Injectable({
   providedIn: 'root',
@@ -64,5 +65,17 @@ export class ProjectService {
       { keyId },
       console.log
     );
+  }
+
+  async inviteProjectMember(request: { email: string; role: ProjectRoles }) {
+    const projectId = this.currentProjectId;
+    if (!projectId) {
+      throw new Error('No project selected. Please select a project first.');
+    }
+    return this.apiService.inviteProjectMember({
+      projectId,
+      email: request.email,
+      role: request.role,
+    });
   }
 }

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -101,4 +101,12 @@ export class ProjectService {
       memberId,
     });
   }
+
+  async revokeProjectInvitation(invitationId: string) {
+    const projectId = this.currentProjectId;
+    if (!projectId) {
+      throw new Error('No project selected. Please select a project first.');
+    }
+    return this.firebaseDataService.deleteProjectInvitation(projectId, invitationId);
+  }
 }

--- a/frontend/src/app/testing/mocks.ts
+++ b/frontend/src/app/testing/mocks.ts
@@ -15,6 +15,7 @@ export class MockFirebaseDataService {
   get agents() { return () => []; }
   get machines() { return () => []; }
   get userProjects() { return () => []; }
+  get notifications() { return () => []; }
   get projectSettings() { return () => null; }
   get projectId() { return () => 'test-project'; }
   get agentId() { return () => ''; }

--- a/frontend/src/app/testing/mocks.ts
+++ b/frontend/src/app/testing/mocks.ts
@@ -74,7 +74,8 @@ export class MockAuthService {
   loginWithEmail(_email: string, _password: string) { return Promise.resolve(); }
   registerWithEmail(_email: string, _password: string) { return Promise.resolve(); }
   sendEmailLinkForCurrentUser(_email: string) { return Promise.resolve(); }
-  completePendingEmailLink() { return Promise.resolve<'linked' | 'none'>('none'); }
+  hasPendingEmailLinkInUrl() { return false; }
+  completePendingEmailLink(_emailOverride?: string) { return Promise.resolve<'linked' | 'none'>('none'); }
   logout() { return Promise.resolve(); }
   getAuth() { return {} as any; }
 }

--- a/frontend/src/app/testing/mocks.ts
+++ b/frontend/src/app/testing/mocks.ts
@@ -73,6 +73,8 @@ export class MockAuthService {
   loginWithGithub() { return Promise.resolve(); }
   loginWithEmail(_email: string, _password: string) { return Promise.resolve(); }
   registerWithEmail(_email: string, _password: string) { return Promise.resolve(); }
+  sendEmailLinkForCurrentUser(_email: string) { return Promise.resolve(); }
+  completePendingEmailLink() { return Promise.resolve<'linked' | 'none'>('none'); }
   logout() { return Promise.resolve(); }
   getAuth() { return {} as any; }
 }

--- a/frontend/src/app/testing/mocks.ts
+++ b/frontend/src/app/testing/mocks.ts
@@ -74,8 +74,10 @@ export class MockAuthService {
   loginWithEmail(_email: string, _password: string) { return Promise.resolve(); }
   registerWithEmail(_email: string, _password: string) { return Promise.resolve(); }
   sendEmailLinkForCurrentUser(_email: string) { return Promise.resolve(); }
+  sendInvitationEmailLink(_email: string, _continueUrl: string) { return Promise.resolve(); }
   hasPendingEmailLinkInUrl() { return false; }
   completePendingEmailLink(_emailOverride?: string) { return Promise.resolve<'linked' | 'none'>('none'); }
+  signInWithInvitationEmailLink(_email: string) { return Promise.resolve<'signed-in' | 'none'>('signed-in'); }
   logout() { return Promise.resolve(); }
   getAuth() { return {} as any; }
 }

--- a/frontend/src/app/testing/mocks.ts
+++ b/frontend/src/app/testing/mocks.ts
@@ -85,6 +85,7 @@ export class MockProjectService {
   currentProjectId = 'test-project';
   currentProject = new BehaviorSubject<string>('test-project');
   userProjectsObservable$ = of([{ projectId: 'test-project' }]);
+  inviteProjectMember() { return Promise.resolve({}); }
 }
 
 export class MockServerService {

--- a/frontend/src/app/testing/mocks.ts
+++ b/frontend/src/app/testing/mocks.ts
@@ -90,6 +90,8 @@ export class MockProjectService {
   currentProject = new BehaviorSubject<string>('test-project');
   userProjectsObservable$ = of([{ projectId: 'test-project' }]);
   inviteProjectMember() { return Promise.resolve({}); }
+  updateProjectMemberRole() { return Promise.resolve({}); }
+  removeProjectMember() { return Promise.resolve({}); }
 }
 
 export class MockServerService {

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc --project ./",
-    "makeZip": "npm run build && zip -r ../terraform/storageObjectFunctions.zip .",
+    "makeZip": "npm run build && bash ./scripts/make_deterministic_zip.sh",
     "format": "prettier -w ./src",
     "dev": "nodemon"
   },

--- a/functions/scripts/make_deterministic_zip.sh
+++ b/functions/scripts/make_deterministic_zip.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAGE_DIR="$ROOT_DIR/.zip-stage"
+OUTPUT_ZIP="$ROOT_DIR/../terraform/storageObjectFunctions.zip"
+
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+rm -f "$OUTPUT_ZIP"
+
+cp -R "$ROOT_DIR/src" "$STAGE_DIR/src"
+cp "$ROOT_DIR/index.ts" "$STAGE_DIR/index.ts"
+cp "$ROOT_DIR/tsconfig.json" "$STAGE_DIR/tsconfig.json"
+cp "$ROOT_DIR/package.json" "$STAGE_DIR/package.json"
+cp "$ROOT_DIR/package-lock.json" "$STAGE_DIR/package-lock.json"
+
+# Use a fixed timestamp to keep zip metadata deterministic.
+find "$STAGE_DIR" -exec touch -t 202001010000 {} +
+
+(
+  cd "$STAGE_DIR"
+  find . -type f | LC_ALL=C sort | zip -X -q "$OUTPUT_ZIP" -@
+)
+
+rm -rf "$STAGE_DIR"

--- a/integration-tests/docker-compose.dev.yml
+++ b/integration-tests/docker-compose.dev.yml
@@ -19,6 +19,8 @@ services:
       - FIREBASE_APP_ID=${FIREBASE_APP_ID}
       - NSTRUMENTA_API_KEY_PEPPER=${NSTRUMENTA_API_KEY_PEPPER}
       - NST_API_URL=http://localhost:5999
+      - CHOKIDAR_USEPOLLING=true
+      - CHOKIDAR_INTERVAL=1000
     volumes:
       - ${HOME}/.config/gcloud:/root/.config/gcloud:ro
       - ../server/app/src:/build/server/app/src

--- a/integration-tests/e2e.sh
+++ b/integration-tests/e2e.sh
@@ -11,16 +11,18 @@ cd "$(dirname "$0")"
 
 START_SECONDS=$SECONDS
 CLI_TEST_ARGS=""
-PLAYWRIGHT_TEST_ARGS=""
+PLAYWRIGHT_TEST_ARGS=()
 for arg in "$@"; do
     if echo "$arg" | grep -q 'tests/.*\.ts'; then
         CLI_TEST_ARGS="$arg"
     else
-        PLAYWRIGHT_TEST_ARGS="$PLAYWRIGHT_TEST_ARGS $arg"
+        normalized_arg="${arg#./}"
+        normalized_arg="${normalized_arg#tests/}"
+        PLAYWRIGHT_TEST_ARGS+=("$normalized_arg")
     fi
 done
 export CLI_TEST_ARGS
-TEST_ARGS="$PLAYWRIGHT_TEST_ARGS"
+TEST_ARGS="$(printf ' %q' "${PLAYWRIGHT_TEST_ARGS[@]}")"
 
 if [ -z "$GOOGLE_CLOUD_PROJECT" ]; then
     echo "GOOGLE_CLOUD_PROJECT is not set. Run: source credentials/activate.sh"
@@ -69,9 +71,9 @@ docker compose $COMPOSE_FILES run --build --rm cli-tests
 CLI_EXIT_CODE=$?
 set -e
 
-if [ -n "$TEST_ARGS" ]; then
+if [ ${#PLAYWRIGHT_TEST_ARGS[@]} -gt 0 ]; then
     set +e
-    docker compose $COMPOSE_FILES run --rm playwright sh -c "npm install && npm run test:playwright -- $TEST_ARGS"
+    docker compose $COMPOSE_FILES run --rm playwright sh -c "npm install && npm run test:playwright --$TEST_ARGS"
     PLAYWRIGHT_EXIT_CODE=$?
     set -e
 else

--- a/integration-tests/e2e.sh
+++ b/integration-tests/e2e.sh
@@ -17,7 +17,7 @@ for arg in "$@"; do
         CLI_TEST_ARGS="$arg"
     else
         normalized_arg="${arg#./}"
-        normalized_arg="${normalized_arg#tests/}"
+        normalized_arg="${normalized_arg#frontend/}"
         PLAYWRIGHT_TEST_ARGS+=("$normalized_arg")
     fi
 done
@@ -73,7 +73,7 @@ set -e
 
 if [ ${#PLAYWRIGHT_TEST_ARGS[@]} -gt 0 ]; then
     set +e
-    docker compose $COMPOSE_FILES run --rm playwright sh -c "npm install && npm run test:playwright --$TEST_ARGS"
+    docker compose $COMPOSE_FILES run --build --rm playwright sh -c "npm install && npm run test:playwright --$TEST_ARGS"
     PLAYWRIGHT_EXIT_CODE=$?
     set -e
 else

--- a/integration-tests/frontend-e2e-watch.sh
+++ b/integration-tests/frontend-e2e-watch.sh
@@ -27,7 +27,13 @@ case "$SUBCOMMAND" in
 esac
 
 START_SECONDS=$SECONDS
-TEST_ARGS="$*"
+PLAYWRIGHT_TEST_ARGS=()
+for arg in "$@"; do
+    normalized_arg="${arg#./}"
+    normalized_arg="${normalized_arg#tests/}"
+    PLAYWRIGHT_TEST_ARGS+=("$normalized_arg")
+done
+TEST_ARGS="$(printf ' %q' "${PLAYWRIGHT_TEST_ARGS[@]}")"
 
 # Verify the watch stack is running before wasting time on setup
 if ! docker compose $COMPOSE_FILES exec -T server sh -c "wget -qO- http://localhost:5999/health" > /dev/null 2>&1; then
@@ -61,9 +67,9 @@ trap cleanup_users EXIT
 export NSTRUMENTA_API_KEY=$(node create-api-key.js "${TEST_USER_USERNAME}/ci" http://server:5999)
 
 PLAYWRIGHT_EXIT_CODE=0
-if [ -n "$TEST_ARGS" ]; then
+if [ ${#PLAYWRIGHT_TEST_ARGS[@]} -gt 0 ]; then
     set +e
-    docker compose $COMPOSE_FILES run --rm --no-deps playwright sh -c "npm run test:playwright -- $TEST_ARGS"
+    docker compose $COMPOSE_FILES run --rm --no-deps playwright sh -c "npm run test:playwright --$TEST_ARGS"
     PLAYWRIGHT_EXIT_CODE=$?
     set -e
 else

--- a/integration-tests/frontend-e2e.sh
+++ b/integration-tests/frontend-e2e.sh
@@ -13,7 +13,7 @@ START_SECONDS=$SECONDS
 PLAYWRIGHT_TEST_ARGS=()
 for arg in "$@"; do
     normalized_arg="${arg#./}"
-    normalized_arg="${normalized_arg#tests/}"
+    normalized_arg="${normalized_arg#frontend/}"
     PLAYWRIGHT_TEST_ARGS+=("$normalized_arg")
 done
 TEST_ARGS="$(printf ' %q' "${PLAYWRIGHT_TEST_ARGS[@]}")"
@@ -60,7 +60,7 @@ docker compose $COMPOSE_FILES up --build -d server
 PLAYWRIGHT_EXIT_CODE=0
 if [ ${#PLAYWRIGHT_TEST_ARGS[@]} -gt 0 ]; then
     set +e
-    docker compose $COMPOSE_FILES run --rm playwright sh -c "npm install && npm run test:playwright --$TEST_ARGS"
+    docker compose $COMPOSE_FILES run --build --rm playwright sh -c "npm install && npm run test:playwright --$TEST_ARGS"
     PLAYWRIGHT_EXIT_CODE=$?
     set -e
 else

--- a/integration-tests/frontend-e2e.sh
+++ b/integration-tests/frontend-e2e.sh
@@ -4,14 +4,20 @@
 # Prerequisites: source credentials/activate.sh
 #
 # Usage:
-#   ./frontend-e2e.sh                    # run all tests
-#   ./frontend-e2e.sh tests/foo.spec.js  # run specific test file
+#   ./frontend-e2e.sh                                   # run all tests
+#   ./frontend-e2e.sh tests/foo.spec.js                 # run specific test file
+#   ./frontend-e2e.sh --rebuild-frontend                # force frontend rebuild before running
 
 cd "$(dirname "$0")"
 
 START_SECONDS=$SECONDS
+REBUILD_FRONTEND=false
 PLAYWRIGHT_TEST_ARGS=()
 for arg in "$@"; do
+    if [ "$arg" = "--rebuild-frontend" ]; then
+        REBUILD_FRONTEND=true
+        continue
+    fi
     normalized_arg="${arg#./}"
     normalized_arg="${normalized_arg#frontend/}"
     PLAYWRIGHT_TEST_ARGS+=("$normalized_arg")
@@ -29,7 +35,7 @@ eval "$(node get-project-config.js)"
 NSTRUMENTA_API_KEY_PEPPER=$(gcloud secrets versions access latest --secret=NSTRUMENTA_API_KEY_PEPPER --project=$GOOGLE_CLOUD_PROJECT)
 export NSTRUMENTA_API_KEY_PEPPER
 
-if [ ! -d "../frontend/dist" ]; then
+if [ "$REBUILD_FRONTEND" = true ] || [ ! -d "../frontend/dist" ]; then
     echo "Building frontend..."
     (cd ../frontend && npm install && npm run build)
 fi

--- a/integration-tests/frontend-e2e.sh
+++ b/integration-tests/frontend-e2e.sh
@@ -10,7 +10,13 @@
 cd "$(dirname "$0")"
 
 START_SECONDS=$SECONDS
-TEST_ARGS="$*"
+PLAYWRIGHT_TEST_ARGS=()
+for arg in "$@"; do
+    normalized_arg="${arg#./}"
+    normalized_arg="${normalized_arg#tests/}"
+    PLAYWRIGHT_TEST_ARGS+=("$normalized_arg")
+done
+TEST_ARGS="$(printf ' %q' "${PLAYWRIGHT_TEST_ARGS[@]}")"
 
 if [ -z "$GOOGLE_CLOUD_PROJECT" ]; then
     echo "GOOGLE_CLOUD_PROJECT is not set. Run: source credentials/activate.sh"
@@ -52,9 +58,9 @@ COMPOSE_FILES="-f docker-compose.e2e.yml"
 docker compose $COMPOSE_FILES up --build -d server
 
 PLAYWRIGHT_EXIT_CODE=0
-if [ -n "$TEST_ARGS" ]; then
+if [ ${#PLAYWRIGHT_TEST_ARGS[@]} -gt 0 ]; then
     set +e
-    docker compose $COMPOSE_FILES run --rm playwright sh -c "npm install && npm run test:playwright -- $TEST_ARGS"
+    docker compose $COMPOSE_FILES run --rm playwright sh -c "npm install && npm run test:playwright --$TEST_ARGS"
     PLAYWRIGHT_EXIT_CODE=$?
     set -e
 else

--- a/integration-tests/frontend/tests/invitations.spec.js
+++ b/integration-tests/frontend/tests/invitations.spec.js
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL;
 const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD;
+const TEST_USER_USERNAME = TEST_USER_EMAIL ? TEST_USER_EMAIL.split('@')[0] : '';
 
 if (!TEST_USER_EMAIL || !TEST_USER_PASSWORD) {
   throw new Error('TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables are required');
@@ -21,6 +22,8 @@ async function signIn(page) {
     await page.locator('button[type="submit"]:has-text("Sign In")').click();
     await page.locator('h2:has-text("Sign In")').waitFor({ state: 'hidden' });
   }
+
+  await expect(page.locator('app-navbar-account button[mat-icon-button]')).toBeVisible({ timeout: 15000 });
 }
 
 test.describe('Invitations and Notifications UX', () => {
@@ -30,7 +33,7 @@ test.describe('Invitations and Notifications UX', () => {
     await page.goto('/account');
     await expect(page.locator('mat-toolbar:has-text("User Settings")')).toBeVisible();
 
-    await page.locator('mat-toolbar button:has(mat-icon:text("account_circle"))').click();
+    await page.locator('app-navbar-account button[mat-icon-button]').click();
     await expect(page.locator('button[mat-menu-item]:has-text("Notifications")')).toBeVisible();
     await page.locator('button[mat-menu-item]:has-text("Notifications")').click();
     await expect(page).toHaveURL(/\/account\/notifications/);
@@ -41,21 +44,21 @@ test.describe('Invitations and Notifications UX', () => {
 
     await page.goto('/');
 
+    const projectName = `invite-flow-${Date.now()}`;
     const fabButton = page.locator('button#fab mat-icon:has-text("add")');
     await expect(fabButton).toBeVisible();
     await fabButton.click();
 
     await expect(page.locator('h2:has-text("Add New Project")')).toBeVisible();
-
-    const projectName = `invite-flow-${Date.now()}`;
     await page.locator('app-new-project-dialog mat-form-field').first().locator('input').fill(projectName);
     await expect(page.locator('app-new-project-dialog mat-select')).not.toHaveAttribute('aria-disabled', 'true');
     await page.locator('app-new-project-dialog mat-select').click();
     await page.locator('mat-option').first().click();
     await page.locator('button:has-text("Create")').click();
 
-    await expect(page).toHaveURL(/\/settings|\/data/);
-    await page.goto(page.url().replace(/\/(data|record|actions|agents|machines|repositories|modules).*$/, '/settings'));
+    await expect(page).toHaveURL(/\/(overview|data)/);
+    await page.locator('a[mat-list-item]:has-text("Settings")').click();
+    await expect(page).toHaveURL(/\/settings/);
 
     await expect(page.locator('button:has-text("Invite Member")')).toBeVisible();
     await page.locator('button:has-text("Invite Member")').click();
@@ -69,6 +72,6 @@ test.describe('Invitations and Notifications UX', () => {
     await signIn(page);
 
     await page.goto('/accept-invite?orgId=test-org');
-    await expect(page.locator('mat-card-content')).toContainText('Missing invitation parameters.');
+    await expect(page.locator('text=Missing invitation parameters.')).toBeVisible();
   });
 });

--- a/integration-tests/frontend/tests/invitations.spec.js
+++ b/integration-tests/frontend/tests/invitations.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL;
+const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD;
+
+if (!TEST_USER_EMAIL || !TEST_USER_PASSWORD) {
+  throw new Error('TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables are required');
+}
+
+async function signIn(page) {
+  await page.goto('/');
+  await Promise.race([
+    page.locator('button:has-text("Sign in"), button[mat-icon-button]').first().waitFor({ state: 'visible' }),
+  ]);
+
+  if (await page.locator('button:has-text("Sign in")').isVisible()) {
+    await page.locator('button:has-text("Sign in")').click();
+    await expect(page.locator('h2:has-text("Sign In")')).toBeVisible();
+    await page.locator('input[name="email"]').fill(TEST_USER_EMAIL);
+    await page.locator('input[name="password"]').fill(TEST_USER_PASSWORD);
+    await page.locator('button[type="submit"]:has-text("Sign In")').click();
+    await page.locator('h2:has-text("Sign In")').waitFor({ state: 'hidden' });
+  }
+}
+
+test.describe('Invitations and Notifications UX', () => {
+  test('notifications is discoverable from account menu and settings', async ({ page }) => {
+    await signIn(page);
+
+    await page.goto('/account');
+    await expect(page.locator('mat-toolbar:has-text("User Settings")')).toBeVisible();
+
+    await page.locator('mat-toolbar button:has(mat-icon:text("account_circle"))').click();
+    await expect(page.locator('button[mat-menu-item]:has-text("Notifications")')).toBeVisible();
+    await page.locator('button[mat-menu-item]:has-text("Notifications")').click();
+    await expect(page).toHaveURL(/\/account\/notifications/);
+  });
+
+  test('project settings invite dialog opens with email and role fields', async ({ page }) => {
+    await signIn(page);
+
+    await page.goto('/');
+
+    const fabButton = page.locator('button#fab mat-icon:has-text("add")');
+    await expect(fabButton).toBeVisible();
+    await fabButton.click();
+
+    await expect(page.locator('h2:has-text("Add New Project")')).toBeVisible();
+
+    const projectName = `invite-flow-${Date.now()}`;
+    await page.locator('app-new-project-dialog mat-form-field').first().locator('input').fill(projectName);
+    await expect(page.locator('app-new-project-dialog mat-select')).not.toHaveAttribute('aria-disabled', 'true');
+    await page.locator('app-new-project-dialog mat-select').click();
+    await page.locator('mat-option').first().click();
+    await page.locator('button:has-text("Create")').click();
+
+    await expect(page).toHaveURL(/\/settings|\/data/);
+    await page.goto(page.url().replace(/\/(data|record|actions|agents|machines|repositories|modules).*$/, '/settings'));
+
+    await expect(page.locator('button:has-text("Invite Member")')).toBeVisible();
+    await page.locator('button:has-text("Invite Member")').click();
+
+    await expect(page.locator('h2:has-text("Invite Project Member")')).toBeVisible();
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('mat-select')).toBeVisible();
+  });
+
+  test('accept-invite route shows missing parameter guidance', async ({ page }) => {
+    await signIn(page);
+
+    await page.goto('/accept-invite?orgId=test-org');
+    await expect(page.locator('mat-card-content')).toContainText('Missing invitation parameters.');
+  });
+});

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -270,6 +270,19 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -293,9 +306,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -321,9 +334,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -339,15 +352,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -863,9 +876,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -875,13 +888,14 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -891,9 +905,11 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -935,9 +951,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
-      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -947,9 +963,7 @@
         "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.4.0",
-        "uuid": "^11.0.2"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1682,15 +1696,6 @@
         }
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -1728,9 +1733,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -1757,22 +1762,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -1918,9 +1923,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -2021,19 +2026,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -2108,6 +2100,22 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/integration-tests/readme.md
+++ b/integration-tests/readme.md
@@ -25,12 +25,10 @@ Credentials are written to `integration-tests/.seed-output` (gitignored, mode 06
 ## Running Tests
 
 ```shell
-# From repo root
-npm run test:e2e
-
-# CLI E2E only
-cd integration-tests && ./e2e.sh
+source credentials/activate.sh && npm run test:e2e -- --rebuild-frontend
 ```
+
+The `--rebuild-frontend` flag forces a frontend build before running. Omit it in CI where `frontend/dist` is built fresh as part of the pipeline.
 
 Each test run creates an ephemeral user with randomised credentials via `globalSetup.ts`
 and deletes them on teardown — no manual seeding required for CI.

--- a/server/app/package-lock.json
+++ b/server/app/package-lock.json
@@ -857,6 +857,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -899,9 +911,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -927,9 +939,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -945,9 +957,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2382,12 +2394,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2444,9 +2456,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2460,9 +2472,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2471,13 +2483,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -2486,9 +2499,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3244,9 +3259,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3352,9 +3367,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4173,9 +4188,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -4266,9 +4281,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -4323,22 +4338,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -4902,9 +4917,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -5153,9 +5168,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -5507,6 +5522,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/server/app/src/__tests__/projectAuth.test.ts
+++ b/server/app/src/__tests__/projectAuth.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Request, Response } from 'express'
+
+const { mockAuthFn, mockFirebaseAuthFn } = vi.hoisted(() => ({
+  mockAuthFn: vi.fn(),
+  mockFirebaseAuthFn: vi.fn(),
+}))
+
+const { mockDocGet, mockDocFn } = vi.hoisted(() => {
+  const mockDocGet = vi.fn()
+  const mockDocFn = vi.fn(() => ({ get: mockDocGet }))
+  return { mockDocGet, mockDocFn }
+})
+
+vi.mock('../authentication/index', () => ({ auth: mockAuthFn }))
+vi.mock('../authentication/firebaseAuth', () => ({ firebaseAuth: mockFirebaseAuthFn }))
+vi.mock('../authentication/ServiceAccount', () => ({
+  firestore: { doc: mockDocFn },
+}))
+
+import { withProjectAuth } from '../authentication/projectAuth'
+
+function makeRes(): Partial<Response> & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+  const res: any = {}
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  res.send = vi.fn().mockReturnValue(res)
+  res.set = vi.fn().mockReturnValue(res)
+  return res
+}
+
+function makeReq(overrides: Partial<Request> = {}): Partial<Request> {
+  return { headers: {}, body: {}, method: 'POST', params: {}, query: {}, ...overrides }
+}
+
+describe('withProjectAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('CORS preflight', () => {
+    it('returns 204 for OPTIONS', async () => {
+      const handler = withProjectAuth(vi.fn())
+      const req = makeReq({ method: 'OPTIONS' })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(204)
+      expect(res.send).toHaveBeenCalledWith('')
+    })
+  })
+
+  describe('API key authentication', () => {
+    it('calls the handler when API key authenticates and no projectId in request', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: true, projectId: 'org/proj', apiKey: 'k1' })
+      const inner = vi.fn().mockResolvedValue(undefined)
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: {} })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(inner).toHaveBeenCalledWith(
+        req,
+        res,
+        expect.objectContaining({ authenticated: true, type: 'api-key', projectId: 'org/proj' }),
+      )
+    })
+
+    it('calls the handler when API key projectId matches request projectId', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: true, projectId: 'org/proj', apiKey: 'k1' })
+      const inner = vi.fn().mockResolvedValue(undefined)
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'org/proj' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(inner).toHaveBeenCalled()
+    })
+
+    it('returns 403 when API key projectId does not match request projectId', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: true, projectId: 'org/proj', apiKey: 'k1' })
+      const inner = vi.fn()
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'other/proj' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(403)
+      expect(inner).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Firebase user authentication', () => {
+    it('returns 400 when projectId is missing', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: false })
+      mockFirebaseAuthFn.mockResolvedValue({ authenticated: true, userId: 'user1' })
+      const inner = vi.fn()
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: {} })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(inner).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 for invalid projectId format', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: false })
+      mockFirebaseAuthFn.mockResolvedValue({ authenticated: true, userId: 'user1' })
+      const inner = vi.fn()
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'notslashed' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(inner).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 for projectId with more than one slash', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: false })
+      mockFirebaseAuthFn.mockResolvedValue({ authenticated: true, userId: 'user1' })
+      const inner = vi.fn()
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'a/b/c' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(inner).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when project does not exist', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: false })
+      mockFirebaseAuthFn.mockResolvedValue({ authenticated: true, userId: 'user1' })
+      mockDocGet.mockResolvedValue({ exists: false, data: () => undefined })
+      const inner = vi.fn()
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'org/proj' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(403)
+      expect(inner).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when user is not in project members map', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: false })
+      mockFirebaseAuthFn.mockResolvedValue({ authenticated: true, userId: 'user1' })
+      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ members: { user2: true } }) })
+      const inner = vi.fn()
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'org/proj' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(403)
+      expect(inner).not.toHaveBeenCalled()
+    })
+
+    it('calls the handler when user is a project member', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: false })
+      mockFirebaseAuthFn.mockResolvedValue({ authenticated: true, userId: 'user1' })
+      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ members: { user1: true } }) })
+      const inner = vi.fn().mockResolvedValue(undefined)
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'org/proj' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(inner).toHaveBeenCalledWith(
+        req,
+        res,
+        expect.objectContaining({ authenticated: true, type: 'user', projectId: 'org/proj', userId: 'user1' }),
+      )
+    })
+  })
+
+  describe('unauthenticated', () => {
+    it('returns 401 when neither auth method succeeds', async () => {
+      mockAuthFn.mockResolvedValue({ authenticated: false })
+      mockFirebaseAuthFn.mockResolvedValue({ authenticated: false })
+      const inner = vi.fn()
+      const handler = withProjectAuth(inner)
+      const req = makeReq({ body: { projectId: 'org/proj' } })
+      const res = makeRes()
+      await handler(req as Request, res as Response)
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(inner).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/app/src/__tests__/projectInvitations.test.ts
+++ b/server/app/src/__tests__/projectInvitations.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Request, Response } from 'express'
+
+const {
+  mockGetUserByEmail,
+  mockGetUser,
+} = vi.hoisted(() => ({
+  mockGetUserByEmail: vi.fn(),
+  mockGetUser: vi.fn(),
+}))
+
+const {
+  mockDocGet,
+  mockDocSet,
+  mockDocUpdate,
+  mockCollectionGet,
+  mockCollectionDocSet,
+  mockFirestoreDoc,
+  mockFirestoreCollection,
+} = vi.hoisted(() => {
+  const mockDocGet = vi.fn()
+  const mockDocSet = vi.fn().mockResolvedValue(undefined)
+  const mockDocUpdate = vi.fn().mockResolvedValue(undefined)
+  const mockCollectionGet = vi.fn()
+  const mockCollectionDocSet = vi.fn().mockResolvedValue(undefined)
+  const mockCollectionDocUpdate = vi.fn().mockResolvedValue(undefined)
+
+  const mockFirestoreDoc = vi.fn((path: string) => ({
+    get: () => mockDocGet(path),
+    set: (data: unknown) => mockDocSet(path, data),
+    update: (data: unknown) => mockDocUpdate(path, data),
+  }))
+
+  const mockFirestoreCollection = vi.fn((path: string) => ({
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    get: () => mockCollectionGet(path),
+    doc: vi.fn(() => ({
+      id: 'invite-123',
+      set: (data: unknown) => mockCollectionDocSet(path, data),
+      update: (data: unknown) => mockCollectionDocUpdate(path, data),
+    })),
+  }))
+
+  return {
+    mockDocGet,
+    mockDocSet,
+    mockDocUpdate,
+    mockCollectionGet,
+    mockCollectionDocSet,
+    mockFirestoreDoc,
+    mockFirestoreCollection,
+  }
+})
+
+vi.mock('firebase-admin/auth', () => ({
+  getAuth: () => ({
+    getUserByEmail: mockGetUserByEmail,
+    getUser: mockGetUser,
+  }),
+}))
+
+vi.mock('../authentication/ServiceAccount', () => ({
+  firestore: {
+    doc: mockFirestoreDoc,
+    collection: mockFirestoreCollection,
+  },
+}))
+
+vi.mock('../authentication/firebaseAuth', () => ({
+  withFirebaseAuth: (fn: any) => fn,
+}))
+
+import { inviteProjectMember, acceptProjectInvitation } from '../api/invitations'
+
+function makeRes(): any {
+  const res: any = {}
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  res.send = vi.fn().mockReturnValue(res)
+  return res
+}
+
+describe('project invitations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCollectionGet.mockResolvedValue({ empty: true, docs: [] })
+  })
+
+  it('returns 403 when caller is not a project admin', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({ members: { caller1: 'viewer' } }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (inviteProjectMember as any)(req, res, {
+      authenticated: true,
+      userId: 'caller1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      email: 'new@example.com',
+      role: 'viewer',
+    })
+
+    expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it('adds existing user directly to project members map', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockGetUserByEmail.mockResolvedValue({ uid: 'user-2' })
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({ members: { caller1: 'admin' } }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (inviteProjectMember as any)(req, res, {
+      authenticated: true,
+      userId: 'caller1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      email: 'existing@example.com',
+      role: 'viewer',
+    })
+
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      'organizations/org1/projects/proj1',
+      expect.objectContaining({
+        members: expect.objectContaining({ 'user-2': 'viewer' }),
+      }),
+    )
+    expect(res.status).toHaveBeenCalledWith(201)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'accepted', existingUser: true }))
+  })
+
+  it('accepts project invitation when user email matches', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockGetUser.mockResolvedValue({ email: 'invited@example.com' })
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1/invitations/invite-1') {
+        return {
+          exists: true,
+          data: () => ({
+            email: 'invited@example.com',
+            role: 'viewer',
+            status: 'pending',
+            expiresAt: Date.now() + 60_000,
+          }),
+        }
+      }
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({ members: { admin1: 'admin' } }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (acceptProjectInvitation as any)(req, res, {
+      authenticated: true,
+      userId: 'user-2',
+      orgId: 'org1',
+      projectId: 'proj1',
+      invitationId: 'invite-1',
+    })
+
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      'organizations/org1/projects/proj1',
+      expect.objectContaining({
+        members: expect.objectContaining({ 'user-2': 'viewer' }),
+      }),
+    )
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      'organizations/org1/projects/proj1/invitations/invite-1',
+      expect.objectContaining({ status: 'accepted', acceptedBy: 'user-2' }),
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('rejects project invitation acceptance when user email does not match', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockGetUser.mockResolvedValue({ email: 'other@example.com' })
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1/invitations/invite-1') {
+        return {
+          exists: true,
+          data: () => ({
+            email: 'invited@example.com',
+            role: 'viewer',
+            status: 'pending',
+            expiresAt: Date.now() + 60_000,
+          }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (acceptProjectInvitation as any)(req, res, {
+      authenticated: true,
+      userId: 'user-2',
+      orgId: 'org1',
+      projectId: 'proj1',
+      invitationId: 'invite-1',
+    })
+
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(mockDocUpdate).not.toHaveBeenCalledWith(
+      'organizations/org1/projects/proj1',
+      expect.anything(),
+    )
+  })
+})

--- a/server/app/src/__tests__/projectInvitations.test.ts
+++ b/server/app/src/__tests__/projectInvitations.test.ts
@@ -4,9 +4,11 @@ import { Request, Response } from 'express'
 const {
   mockGetUserByEmail,
   mockGetUser,
+  mockGenerateSignInWithEmailLink,
 } = vi.hoisted(() => ({
   mockGetUserByEmail: vi.fn(),
   mockGetUser: vi.fn(),
+  mockGenerateSignInWithEmailLink: vi.fn(),
 }))
 
 const {
@@ -57,6 +59,7 @@ vi.mock('firebase-admin/auth', () => ({
   getAuth: () => ({
     getUserByEmail: mockGetUserByEmail,
     getUser: mockGetUser,
+    generateSignInWithEmailLink: mockGenerateSignInWithEmailLink,
   }),
 }))
 
@@ -85,6 +88,7 @@ describe('project invitations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] })
+    mockGenerateSignInWithEmailLink.mockResolvedValue('https://example.com/invite-link')
   })
 
   it('returns 403 when caller is not a project admin', async () => {
@@ -114,7 +118,7 @@ describe('project invitations', () => {
   })
 
   it('adds existing user directly to project members map', async () => {
-    const req = { body: {} } as Request
+    const req = { body: {}, headers: { origin: 'https://app.example.com' } } as Request
     const res = makeRes() as Response
 
     mockGetUserByEmail.mockResolvedValue({ uid: 'user-2' })
@@ -143,8 +147,50 @@ describe('project invitations', () => {
         members: expect.objectContaining({ 'user-2': 'viewer' }),
       }),
     )
+    expect(mockCollectionDocSet).toHaveBeenCalledWith(
+      'users/user-2/notifications',
+      expect.objectContaining({
+        type: 'project_membership_added',
+        projectId: 'org1/proj1',
+      }),
+    )
     expect(res.status).toHaveBeenCalledWith(201)
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'accepted', existingUser: true }))
+  })
+
+  it('generates Firebase sign-in link for new-user project invitations', async () => {
+    const req = { body: {}, headers: { origin: 'https://app.example.com' } } as Request
+    const res = makeRes() as Response
+
+    mockGetUserByEmail.mockRejectedValue(new Error('not found'))
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({ members: { caller1: 'admin' } }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (inviteProjectMember as any)(req, res, {
+      authenticated: true,
+      userId: 'caller1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      email: 'new@example.com',
+      role: 'viewer',
+    })
+
+    expect(mockGenerateSignInWithEmailLink).toHaveBeenCalledWith(
+      'new@example.com',
+      expect.objectContaining({
+        url: expect.stringContaining('/accept-invite?'),
+        handleCodeInApp: true,
+      }),
+    )
+    expect(res.status).toHaveBeenCalledWith(201)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending', existingUser: false }))
   })
 
   it('accepts project invitation when user email matches', async () => {

--- a/server/app/src/__tests__/projectInvitations.test.ts
+++ b/server/app/src/__tests__/projectInvitations.test.ts
@@ -117,7 +117,7 @@ describe('project invitations', () => {
     expect(res.status).toHaveBeenCalledWith(403)
   })
 
-  it('adds existing user directly to project members map', async () => {
+  it('creates pending invitation and notifies existing user', async () => {
     const req = { body: {}, headers: { origin: 'https://app.example.com' } } as Request
     const res = makeRes() as Response
 
@@ -141,17 +141,12 @@ describe('project invitations', () => {
       role: 'viewer',
     })
 
-    expect(mockDocUpdate).toHaveBeenCalledWith(
-      'organizations/org1/projects/proj1',
-      expect.objectContaining({
-        members: expect.objectContaining({ 'user-2': 'viewer' }),
-      }),
-    )
     expect(mockCollectionDocSet).toHaveBeenCalledWith(
       'users/user-2/notifications',
       expect.objectContaining({
-        type: 'project_membership_added',
+        type: 'project_invitation_pending',
         projectId: 'org1/proj1',
+        invitationId: 'invite-123',
       }),
     )
     expect(mockGenerateSignInWithEmailLink).toHaveBeenCalledWith(
@@ -163,13 +158,13 @@ describe('project invitations', () => {
     )
     expect(res.status).toHaveBeenCalledWith(201)
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'accepted',
+      status: 'pending',
       existingUser: true,
       delivery: 'firebase_signin_link',
     }))
   })
 
-  it('keeps auto-accepted invite successful when email-link delivery fails', async () => {
+  it('keeps pending invite successful when email-link delivery fails', async () => {
     const req = { body: {}, headers: { origin: 'https://app.example.com' } } as Request
     const res = makeRes() as Response
 
@@ -197,12 +192,12 @@ describe('project invitations', () => {
     expect(mockCollectionDocSet).toHaveBeenCalledWith(
       'users/user-2/notifications',
       expect.objectContaining({
-        type: 'project_membership_added',
+        type: 'project_invitation_pending',
       }),
     )
     expect(res.status).toHaveBeenCalledWith(201)
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'accepted',
+      status: 'pending',
       existingUser: true,
       delivery: 'none',
     }))
@@ -286,6 +281,13 @@ describe('project invitations', () => {
     expect(mockDocUpdate).toHaveBeenCalledWith(
       'organizations/org1/projects/proj1/invitations/invite-1',
       expect.objectContaining({ status: 'accepted', acceptedBy: 'user-2' }),
+    )
+    expect(mockCollectionDocSet).toHaveBeenCalledWith(
+      'users/user-2/notifications',
+      expect.objectContaining({
+        type: 'project_membership_added',
+        projectId: 'org1/proj1',
+      }),
     )
     expect(res.status).toHaveBeenCalledWith(200)
   })

--- a/server/app/src/__tests__/projectInvitations.test.ts
+++ b/server/app/src/__tests__/projectInvitations.test.ts
@@ -4,11 +4,9 @@ import { Request, Response } from 'express'
 const {
   mockGetUserByEmail,
   mockGetUser,
-  mockGenerateSignInWithEmailLink,
 } = vi.hoisted(() => ({
   mockGetUserByEmail: vi.fn(),
   mockGetUser: vi.fn(),
-  mockGenerateSignInWithEmailLink: vi.fn(),
 }))
 
 const {
@@ -17,6 +15,7 @@ const {
   mockDocUpdate,
   mockCollectionGet,
   mockCollectionDocSet,
+  mockCollectionDocDelete,
   mockFirestoreDoc,
   mockFirestoreCollection,
 } = vi.hoisted(() => {
@@ -26,6 +25,7 @@ const {
   const mockCollectionGet = vi.fn()
   const mockCollectionDocSet = vi.fn().mockResolvedValue(undefined)
   const mockCollectionDocUpdate = vi.fn().mockResolvedValue(undefined)
+  const mockCollectionDocDelete = vi.fn().mockResolvedValue(undefined)
 
   const mockFirestoreDoc = vi.fn((path: string) => ({
     get: () => mockDocGet(path),
@@ -37,10 +37,11 @@ const {
     where: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     get: () => mockCollectionGet(path),
-    doc: vi.fn(() => ({
-      id: 'invite-123',
+    doc: vi.fn((docId?: string) => ({
+      id: docId ?? 'invite-123',
       set: (data: unknown) => mockCollectionDocSet(path, data),
       update: (data: unknown) => mockCollectionDocUpdate(path, data),
+      delete: () => mockCollectionDocDelete(path, docId),
     })),
   }))
 
@@ -50,6 +51,7 @@ const {
     mockDocUpdate,
     mockCollectionGet,
     mockCollectionDocSet,
+    mockCollectionDocDelete,
     mockFirestoreDoc,
     mockFirestoreCollection,
   }
@@ -59,7 +61,6 @@ vi.mock('firebase-admin/auth', () => ({
   getAuth: () => ({
     getUserByEmail: mockGetUserByEmail,
     getUser: mockGetUser,
-    generateSignInWithEmailLink: mockGenerateSignInWithEmailLink,
   }),
 }))
 
@@ -88,7 +89,6 @@ describe('project invitations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] })
-    mockGenerateSignInWithEmailLink.mockResolvedValue('https://example.com/invite-link')
   })
 
   it('returns 403 when caller is not a project admin', async () => {
@@ -141,35 +141,45 @@ describe('project invitations', () => {
       role: 'viewer',
     })
 
-    expect(mockCollectionDocSet).toHaveBeenCalledWith(
-      'users/user-2/notifications',
+    expect(mockDocSet).toHaveBeenCalledWith(
+      'users/user-2/notifications/invite-123',
       expect.objectContaining({
         type: 'project_invitation_pending',
         projectId: 'org1/proj1',
         invitationId: 'invite-123',
       }),
     )
-    expect(mockGenerateSignInWithEmailLink).toHaveBeenCalledWith(
-      'existing@example.com',
-      expect.objectContaining({
-        url: expect.stringContaining('/accept-invite?'),
-        handleCodeInApp: true,
-      }),
-    )
     expect(res.status).toHaveBeenCalledWith(201)
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
       status: 'pending',
       existingUser: true,
-      delivery: 'firebase_signin_link',
+      requiresEmailBootstrap: false,
+      firebaseEmailLink: expect.objectContaining({
+        email: 'existing@example.com',
+        continueUrl: expect.stringContaining('/accept-invite?'),
+        handleCodeInApp: true,
+      }),
     }))
   })
 
-  it('keeps pending invite successful when email-link delivery fails', async () => {
+  it('reuses an existing pending invitation as a resend', async () => {
     const req = { body: {}, headers: { origin: 'https://app.example.com' } } as Request
     const res = makeRes() as Response
 
     mockGetUserByEmail.mockResolvedValue({ uid: 'user-2' })
-    mockGenerateSignInWithEmailLink.mockRejectedValue(new Error('delivery failed'))
+    mockCollectionGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'invite-existing',
+          data: () => ({
+            email: 'existing@example.com',
+            role: 'viewer',
+            status: 'pending',
+          }),
+        },
+      ],
+    })
     mockDocGet.mockImplementation(async (path: string) => {
       if (path === 'organizations/org1/projects/proj1') {
         return {
@@ -186,24 +196,38 @@ describe('project invitations', () => {
       orgId: 'org1',
       projectId: 'proj1',
       email: 'existing@example.com',
-      role: 'viewer',
+      role: 'admin',
     })
 
-    expect(mockCollectionDocSet).toHaveBeenCalledWith(
-      'users/user-2/notifications',
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      'organizations/org1/projects/proj1/invitations/invite-existing',
       expect.objectContaining({
-        type: 'project_invitation_pending',
+        email: 'existing@example.com',
+        role: 'admin',
+        status: 'pending',
+      }),
+    )
+    expect(mockDocSet).toHaveBeenCalledWith(
+      'users/user-2/notifications/invite-existing',
+      expect.objectContaining({
+        invitationId: 'invite-existing',
+        role: 'admin',
       }),
     )
     expect(res.status).toHaveBeenCalledWith(201)
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'pending',
+      invitationId: 'invite-existing',
       existingUser: true,
-      delivery: 'none',
+      requiresEmailBootstrap: false,
+      firebaseEmailLink: expect.objectContaining({
+        email: 'existing@example.com',
+        continueUrl: expect.stringContaining('/accept-invite?'),
+        handleCodeInApp: true,
+      }),
     }))
   })
 
-  it('generates Firebase sign-in link for new-user project invitations', async () => {
+  it('returns Firebase email bootstrap config for new-user project invitations', async () => {
     const req = { body: {}, headers: { origin: 'https://app.example.com' } } as Request
     const res = makeRes() as Response
 
@@ -227,15 +251,17 @@ describe('project invitations', () => {
       role: 'viewer',
     })
 
-    expect(mockGenerateSignInWithEmailLink).toHaveBeenCalledWith(
-      'new@example.com',
-      expect.objectContaining({
-        url: expect.stringContaining('/accept-invite?'),
+    expect(res.status).toHaveBeenCalledWith(201)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'pending',
+      existingUser: false,
+      requiresEmailBootstrap: true,
+      firebaseEmailLink: expect.objectContaining({
+        email: 'new@example.com',
+        continueUrl: expect.stringContaining('/accept-invite?'),
         handleCodeInApp: true,
       }),
-    )
-    expect(res.status).toHaveBeenCalledWith(201)
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending', existingUser: false }))
+    }))
   })
 
   it('accepts project invitation when user email matches', async () => {
@@ -281,6 +307,10 @@ describe('project invitations', () => {
     expect(mockDocUpdate).toHaveBeenCalledWith(
       'organizations/org1/projects/proj1/invitations/invite-1',
       expect.objectContaining({ status: 'accepted', acceptedBy: 'user-2' }),
+    )
+    expect(mockCollectionDocDelete).toHaveBeenCalledWith(
+      'users/user-2/notifications',
+      'invite-1',
     )
     expect(mockCollectionDocSet).toHaveBeenCalledWith(
       'users/user-2/notifications',

--- a/server/app/src/__tests__/projectInvitations.test.ts
+++ b/server/app/src/__tests__/projectInvitations.test.ts
@@ -154,8 +154,58 @@ describe('project invitations', () => {
         projectId: 'org1/proj1',
       }),
     )
+    expect(mockGenerateSignInWithEmailLink).toHaveBeenCalledWith(
+      'existing@example.com',
+      expect.objectContaining({
+        url: expect.stringContaining('/accept-invite?'),
+        handleCodeInApp: true,
+      }),
+    )
     expect(res.status).toHaveBeenCalledWith(201)
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'accepted', existingUser: true }))
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'accepted',
+      existingUser: true,
+      delivery: 'firebase_signin_link',
+    }))
+  })
+
+  it('keeps auto-accepted invite successful when email-link delivery fails', async () => {
+    const req = { body: {}, headers: { origin: 'https://app.example.com' } } as Request
+    const res = makeRes() as Response
+
+    mockGetUserByEmail.mockResolvedValue({ uid: 'user-2' })
+    mockGenerateSignInWithEmailLink.mockRejectedValue(new Error('delivery failed'))
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({ members: { caller1: 'admin' } }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (inviteProjectMember as any)(req, res, {
+      authenticated: true,
+      userId: 'caller1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      email: 'existing@example.com',
+      role: 'viewer',
+    })
+
+    expect(mockCollectionDocSet).toHaveBeenCalledWith(
+      'users/user-2/notifications',
+      expect.objectContaining({
+        type: 'project_membership_added',
+      }),
+    )
+    expect(res.status).toHaveBeenCalledWith(201)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'accepted',
+      existingUser: true,
+      delivery: 'none',
+    }))
   })
 
   it('generates Firebase sign-in link for new-user project invitations', async () => {

--- a/server/app/src/__tests__/projectMembers.test.ts
+++ b/server/app/src/__tests__/projectMembers.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Request, Response } from 'express'
+
+const { mockDocGet, mockDocUpdate, mockFirestoreDoc } = vi.hoisted(() => {
+  const mockDocGet = vi.fn()
+  const mockDocUpdate = vi.fn().mockResolvedValue(undefined)
+
+  const mockFirestoreDoc = vi.fn((path: string) => ({
+    get: () => mockDocGet(path),
+    update: (data: unknown) => mockDocUpdate(path, data),
+  }))
+
+  return {
+    mockDocGet,
+    mockDocUpdate,
+    mockFirestoreDoc,
+  }
+})
+
+vi.mock('../authentication/ServiceAccount', () => ({
+  firestore: {
+    doc: mockFirestoreDoc,
+  },
+}))
+
+vi.mock('../authentication/firebaseAuth', () => ({
+  withFirebaseAuth: (fn: any) => fn,
+}))
+
+import { removeProjectMember, updateProjectMemberRole } from '../api/projectMembers'
+
+function makeRes(): any {
+  const res: any = {}
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  res.send = vi.fn().mockReturnValue(res)
+  return res
+}
+
+describe('project members api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects admin removing owner', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({
+            members: {
+              admin1: 'admin',
+              owner1: 'owner',
+            },
+          }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (removeProjectMember as any)(req, res, {
+      authenticated: true,
+      userId: 'admin1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      memberId: 'owner1',
+    })
+
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(mockDocUpdate).not.toHaveBeenCalled()
+  })
+
+  it('allows owner removing non-owner', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({
+            members: {
+              owner1: 'owner',
+              viewer1: 'viewer',
+            },
+          }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (removeProjectMember as any)(req, res, {
+      authenticated: true,
+      userId: 'owner1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      memberId: 'viewer1',
+    })
+
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      'organizations/org1/projects/proj1',
+      expect.objectContaining({
+        members: {
+          owner1: 'owner',
+        },
+      }),
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('rejects demoting the last owner', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({
+            members: {
+              owner1: 'owner',
+              admin1: 'admin',
+            },
+          }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (updateProjectMemberRole as any)(req, res, {
+      authenticated: true,
+      userId: 'owner1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      memberId: 'owner1',
+      role: 'admin',
+    })
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(mockDocUpdate).not.toHaveBeenCalled()
+  })
+
+  it('allows owner to promote viewer to admin', async () => {
+    const req = { body: {} } as Request
+    const res = makeRes() as Response
+
+    mockDocGet.mockImplementation(async (path: string) => {
+      if (path === 'organizations/org1/projects/proj1') {
+        return {
+          exists: true,
+          data: () => ({
+            members: {
+              owner1: 'owner',
+              viewer1: 'viewer',
+            },
+          }),
+        }
+      }
+      return { exists: false, data: () => ({}) }
+    })
+
+    await (updateProjectMemberRole as any)(req, res, {
+      authenticated: true,
+      userId: 'owner1',
+      orgId: 'org1',
+      projectId: 'proj1',
+      memberId: 'viewer1',
+      role: 'admin',
+    })
+
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      'organizations/org1/projects/proj1',
+      expect.objectContaining({
+        members: {
+          owner1: 'owner',
+          viewer1: 'admin',
+        },
+      }),
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})

--- a/server/app/src/adminRoutes.ts
+++ b/server/app/src/adminRoutes.ts
@@ -1,17 +1,8 @@
 import express from 'express'
-import rateLimit from 'express-rate-limit'
 import { approveUser, listPendingUsers } from './api/adminUsers'
-
-const adminLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 50,
-  standardHeaders: true,
-  legacyHeaders: false,
-})
 
 export function registerAdminRoutes(app: express.Application) {
   const router = express.Router()
-  router.use(adminLimiter)
 
   router.post('/users/approve', (req, res) => approveUser(req, res))
   router.get('/users/pending', (req, res) => listPendingUsers(req, res))

--- a/server/app/src/api/invitations.ts
+++ b/server/app/src/api/invitations.ts
@@ -181,70 +181,40 @@ const inviteProjectMemberBase = async (
     })
 
     if (existingUser && targetUserId) {
-      await firestore.doc(projectPath).update({
-        members: {
-          ...members,
-          [targetUserId]: role,
-        },
-      })
-
-      await invitationRef.update({
-        status: 'accepted',
-        acceptedAt: timestamp,
-        acceptedBy: targetUserId,
-      })
-
       await firestore.collection(`users/${targetUserId}/notifications`).doc().set({
-        type: 'project_membership_added',
+        type: 'project_invitation_pending',
         orgId,
         projectId: `${orgId}/${projectId}`,
+        invitationId: invitationRef.id,
         role,
         createdAt: timestamp,
         read: false,
-        message: `You were added to project ${orgId}/${projectId} as ${role}`,
-      })
-
-      let delivery: 'firebase_signin_link' | 'none' = 'none'
-      const inviteUrl = buildProjectInviteUrl(req, orgId, projectId, invitationRef.id)
-      if (inviteUrl) {
-        try {
-          await getAuth().generateSignInWithEmailLink(email, {
-            url: inviteUrl,
-            handleCodeInApp: true,
-          })
-          delivery = 'firebase_signin_link'
-        } catch (error) {
-          console.error('Failed to send project invitation email for auto-accepted user:', error)
-        }
-      }
-
-      return res.status(201).json({
-        invitationId: invitationRef.id,
-        email,
-        status: 'accepted',
-        existingUser: true,
-        delivery,
+        message: `You have a pending invitation to join ${orgId}/${projectId} as ${role}`,
       })
     }
 
+    let delivery: 'firebase_signin_link' | 'none' = 'none'
     const inviteUrl = buildProjectInviteUrl(req, orgId, projectId, invitationRef.id)
-    if (!inviteUrl) {
-      return res.status(500).send('NSTRUMENTA_APP_URL or Origin header required for invitation links')
+    if (inviteUrl) {
+      try {
+        await getAuth().generateSignInWithEmailLink(email, {
+          url: inviteUrl,
+          handleCodeInApp: true,
+        })
+        delivery = 'firebase_signin_link'
+      } catch (error) {
+        console.error('Failed to send project invitation email link:', error)
+      }
     }
 
-    await getAuth().generateSignInWithEmailLink(email, {
-      url: inviteUrl,
-      handleCodeInApp: true,
-    })
-
-    console.log(`Project invitation created for ${email} in ${orgId}/${projectId} with Firebase sign-in link`)
+    console.log(`Project invitation created for ${email} in ${orgId}/${projectId}`)
 
     return res.status(201).json({
       invitationId: invitationRef.id,
       email,
       status: 'pending',
-      existingUser: false,
-      delivery: 'firebase_signin_link',
+      existingUser,
+      delivery,
     })
   } catch (error) {
     console.error('Failed to create project invitation:', error)
@@ -300,6 +270,16 @@ const acceptProjectInvitationBase = async (
       status: 'accepted',
       acceptedAt: Date.now(),
       acceptedBy: userId,
+    })
+
+    await firestore.collection(`users/${userId}/notifications`).doc().set({
+      type: 'project_membership_added',
+      orgId,
+      projectId: `${orgId}/${projectId}`,
+      role: invitation.role,
+      createdAt: Date.now(),
+      read: false,
+      message: `You joined project ${orgId}/${projectId} as ${invitation.role}`,
     })
 
     return res.status(200).json({ accepted: true, orgId, projectId })

--- a/server/app/src/api/invitations.ts
+++ b/server/app/src/api/invitations.ts
@@ -5,6 +5,23 @@ import { withFirebaseAuth, FirebaseAuthResult } from '../authentication/firebase
 
 const INVITATION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 
+function getAppUrlFromRequest(req: Request): string | null {
+  const origin = req.headers.origin
+  const appUrl = (typeof origin === 'string' && origin) || process.env.NSTRUMENTA_APP_URL
+  return appUrl || null
+}
+
+function buildProjectInviteUrl(req: Request, orgId: string, projectId: string, invitationId: string): string | null {
+  const appUrl = getAppUrlFromRequest(req)
+  if (!appUrl) return null
+
+  const acceptInviteUrl = new URL('/accept-invite', appUrl)
+  acceptInviteUrl.searchParams.set('orgId', orgId)
+  acceptInviteUrl.searchParams.set('projectId', projectId)
+  acceptInviteUrl.searchParams.set('invitationId', invitationId)
+  return acceptInviteUrl.toString()
+}
+
 // POST /api/orgs/:orgId/invitations
 const inviteMemberBase = async (
   req: Request,
@@ -187,27 +204,36 @@ const inviteProjectMemberBase = async (
         message: `You were added to project ${orgId}/${projectId} as ${role}`,
       })
 
+      let delivery: 'firebase_signin_link' | 'none' = 'none'
+      const inviteUrl = buildProjectInviteUrl(req, orgId, projectId, invitationRef.id)
+      if (inviteUrl) {
+        try {
+          await getAuth().generateSignInWithEmailLink(email, {
+            url: inviteUrl,
+            handleCodeInApp: true,
+          })
+          delivery = 'firebase_signin_link'
+        } catch (error) {
+          console.error('Failed to send project invitation email for auto-accepted user:', error)
+        }
+      }
+
       return res.status(201).json({
         invitationId: invitationRef.id,
         email,
         status: 'accepted',
         existingUser: true,
+        delivery,
       })
     }
 
-    const origin = req.headers.origin
-    const appUrl = (typeof origin === 'string' && origin) || process.env.NSTRUMENTA_APP_URL
-    if (!appUrl) {
+    const inviteUrl = buildProjectInviteUrl(req, orgId, projectId, invitationRef.id)
+    if (!inviteUrl) {
       return res.status(500).send('NSTRUMENTA_APP_URL or Origin header required for invitation links')
     }
 
-    const acceptInviteUrl = new URL('/accept-invite', appUrl)
-    acceptInviteUrl.searchParams.set('orgId', orgId)
-    acceptInviteUrl.searchParams.set('projectId', projectId)
-    acceptInviteUrl.searchParams.set('invitationId', invitationRef.id)
-
     await getAuth().generateSignInWithEmailLink(email, {
-      url: acceptInviteUrl.toString(),
+      url: inviteUrl,
       handleCodeInApp: true,
     })
 

--- a/server/app/src/api/invitations.ts
+++ b/server/app/src/api/invitations.ts
@@ -22,6 +22,50 @@ function buildProjectInviteUrl(req: Request, orgId: string, projectId: string, i
   return acceptInviteUrl.toString()
 }
 
+function createProjectInvitationResponse(
+  invitationId: string,
+  email: string,
+  existingUser: boolean,
+  inviteUrl: string | null,
+) {
+  return {
+    invitationId,
+    email,
+    status: 'pending' as const,
+    existingUser,
+    requiresEmailBootstrap: !existingUser,
+    ...(inviteUrl
+      ? {
+          firebaseEmailLink: {
+            email,
+            continueUrl: inviteUrl,
+            handleCodeInApp: true,
+          },
+        }
+      : {}),
+  }
+}
+
+async function upsertProjectInvitationNotification(
+  userId: string,
+  invitationId: string,
+  orgId: string,
+  projectId: string,
+  role: string,
+  createdAt: number,
+) {
+  await firestore.doc(`users/${userId}/notifications/${invitationId}`).set({
+    type: 'project_invitation_pending',
+    orgId,
+    projectId: `${orgId}/${projectId}`,
+    invitationId,
+    role,
+    createdAt,
+    read: false,
+    message: `You have a pending invitation to join ${orgId}/${projectId} as ${role}`,
+  })
+}
+
 // POST /api/orgs/:orgId/invitations
 const inviteMemberBase = async (
   req: Request,
@@ -165,57 +209,38 @@ const inviteProjectMemberBase = async (
       .limit(1)
       .get()
 
-    if (!existingInvitations.empty) {
-      return res.status(409).send('A pending invitation already exists for this email')
+    const timestamp = Date.now()
+    const existingInvitation = existingInvitations.empty ? null : existingInvitations.docs[0]
+    const invitationId = existingInvitation?.id ?? firestore.collection(invitationPath).doc().id
+    const invitationRef = firestore.doc(`${invitationPath}/${invitationId}`)
+    const inviteUrl = buildProjectInviteUrl(req, orgId, projectId, invitationId)
+
+    if (!inviteUrl) {
+      return res.status(500).send('Project invitation email link is unavailable')
     }
 
-    const timestamp = Date.now()
-    const invitationRef = firestore.collection(invitationPath).doc()
-    await invitationRef.set({
+    const invitationData = {
       email,
       role,
       invitedBy: userId,
       status: 'pending',
       createdAt: timestamp,
       expiresAt: timestamp + INVITATION_EXPIRY_MS,
-    })
-
-    if (existingUser && targetUserId) {
-      await firestore.collection(`users/${targetUserId}/notifications`).doc().set({
-        type: 'project_invitation_pending',
-        orgId,
-        projectId: `${orgId}/${projectId}`,
-        invitationId: invitationRef.id,
-        role,
-        createdAt: timestamp,
-        read: false,
-        message: `You have a pending invitation to join ${orgId}/${projectId} as ${role}`,
-      })
     }
 
-    let delivery: 'firebase_signin_link' | 'none' = 'none'
-    const inviteUrl = buildProjectInviteUrl(req, orgId, projectId, invitationRef.id)
-    if (inviteUrl) {
-      try {
-        await getAuth().generateSignInWithEmailLink(email, {
-          url: inviteUrl,
-          handleCodeInApp: true,
-        })
-        delivery = 'firebase_signin_link'
-      } catch (error) {
-        console.error('Failed to send project invitation email link:', error)
-      }
+    if (existingInvitation) {
+      await invitationRef.update(invitationData)
+    } else {
+      await invitationRef.set(invitationData)
+    }
+
+    if (existingUser && targetUserId) {
+      await upsertProjectInvitationNotification(targetUserId, invitationId, orgId, projectId, role, timestamp)
     }
 
     console.log(`Project invitation created for ${email} in ${orgId}/${projectId}`)
 
-    return res.status(201).json({
-      invitationId: invitationRef.id,
-      email,
-      status: 'pending',
-      existingUser,
-      delivery,
-    })
+    return res.status(201).json(createProjectInvitationResponse(invitationId, email, existingUser, inviteUrl))
   } catch (error) {
     console.error('Failed to create project invitation:', error)
     return res.status(500).send('Failed to create project invitation')
@@ -272,7 +297,10 @@ const acceptProjectInvitationBase = async (
       acceptedBy: userId,
     })
 
-    await firestore.collection(`users/${userId}/notifications`).doc().set({
+    const notificationsRef = firestore.collection(`users/${userId}/notifications`)
+    await notificationsRef.doc(invitationId).delete()
+
+    await notificationsRef.doc().set({
       type: 'project_membership_added',
       orgId,
       projectId: `${orgId}/${projectId}`,
@@ -381,6 +409,9 @@ async function acceptInvitationInternal(
     slug: orgData?.slug || '',
     role: invitation.role,
   })
+
+  // Clear pending invitation notification
+  batch.delete(firestore.doc(`users/${userId}/notifications/${invitationId}`))
 
   await batch.commit()
 }

--- a/server/app/src/api/invitations.ts
+++ b/server/app/src/api/invitations.ts
@@ -121,8 +121,9 @@ const inviteProjectMemberBase = async (
     if (!projectDoc.exists) return res.status(404).send('Project not found')
 
     const members = projectDoc.data()?.members || {}
-    if (members[userId] !== 'admin') {
-      return res.status(403).send('Only project admins can invite members')
+    const inviterRole = members[userId]
+    if (inviterRole !== 'admin' && inviterRole !== 'owner') {
+      return res.status(403).send('Only project owners and admins can invite members')
     }
 
     let existingUser = false

--- a/server/app/src/api/invitations.ts
+++ b/server/app/src/api/invitations.ts
@@ -99,6 +99,164 @@ const inviteMemberBase = async (
 
 export const inviteMember = withFirebaseAuth(inviteMemberBase)
 
+// POST /api/orgs/:orgId/projects/:projectId/invitations
+const inviteProjectMemberBase = async (
+  req: Request,
+  res: Response,
+  args: { orgId: string; projectId: string; email: string; role: string } & FirebaseAuthResult,
+) => {
+  const { authenticated, userId, orgId, projectId, email, role } = args
+  if (!authenticated || !userId) return res.status(401).send('Authentication required')
+  if (!email) return res.status(400).send('email is required')
+
+  const validRoles = ['admin', 'viewer']
+  if (!validRoles.includes(role)) {
+    return res.status(400).send(`role must be one of: ${validRoles.join(', ')}`)
+  }
+
+  const projectPath = `organizations/${orgId}/projects/${projectId}`
+
+  try {
+    const projectDoc = await firestore.doc(projectPath).get()
+    if (!projectDoc.exists) return res.status(404).send('Project not found')
+
+    const members = projectDoc.data()?.members || {}
+    if (members[userId] !== 'admin') {
+      return res.status(403).send('Only project admins can invite members')
+    }
+
+    let existingUser = false
+    let targetUserId: string | null = null
+    try {
+      const userRecord = await getAuth().getUserByEmail(email)
+      targetUserId = userRecord.uid
+      existingUser = true
+
+      if (members[targetUserId]) {
+        return res.status(409).send('User is already a member of this project')
+      }
+    } catch {
+      // User does not exist yet, leave invitation pending.
+    }
+
+    const invitationPath = `${projectPath}/invitations`
+    const existingInvitations = await firestore
+      .collection(invitationPath)
+      .where('email', '==', email)
+      .where('status', '==', 'pending')
+      .limit(1)
+      .get()
+
+    if (!existingInvitations.empty) {
+      return res.status(409).send('A pending invitation already exists for this email')
+    }
+
+    const timestamp = Date.now()
+    const invitationRef = firestore.collection(invitationPath).doc()
+    await invitationRef.set({
+      email,
+      role,
+      invitedBy: userId,
+      status: 'pending',
+      createdAt: timestamp,
+      expiresAt: timestamp + INVITATION_EXPIRY_MS,
+    })
+
+    if (existingUser && targetUserId) {
+      await firestore.doc(projectPath).update({
+        members: {
+          ...members,
+          [targetUserId]: role,
+        },
+      })
+
+      await invitationRef.update({
+        status: 'accepted',
+        acceptedAt: timestamp,
+        acceptedBy: targetUserId,
+      })
+
+      return res.status(201).json({
+        invitationId: invitationRef.id,
+        email,
+        status: 'accepted',
+        existingUser: true,
+      })
+    }
+
+    console.log(`Project invitation created for ${email} in ${orgId}/${projectId} - email sending not yet implemented`)
+
+    return res.status(201).json({
+      invitationId: invitationRef.id,
+      email,
+      status: 'pending',
+      existingUser: false,
+    })
+  } catch (error) {
+    console.error('Failed to create project invitation:', error)
+    return res.status(500).send('Failed to create project invitation')
+  }
+}
+
+export const inviteProjectMember = withFirebaseAuth(inviteProjectMemberBase)
+
+// POST /api/orgs/:orgId/projects/:projectId/invitations/:invitationId/accept
+const acceptProjectInvitationBase = async (
+  req: Request,
+  res: Response,
+  args: { orgId: string; projectId: string; invitationId: string } & FirebaseAuthResult,
+) => {
+  const { authenticated, userId, orgId, projectId, invitationId } = args
+  if (!authenticated || !userId) return res.status(401).send('Authentication required')
+
+  const projectPath = `organizations/${orgId}/projects/${projectId}`
+  const invitationPath = `${projectPath}/invitations/${invitationId}`
+
+  try {
+    const invitationRef = firestore.doc(invitationPath)
+    const invitationDoc = await invitationRef.get()
+    if (!invitationDoc.exists) return res.status(404).send('Invitation not found')
+
+    const invitation = invitationDoc.data()!
+    if (invitation.status !== 'pending') {
+      return res.status(400).send(`Invitation is ${invitation.status}`)
+    }
+    if (invitation.expiresAt < Date.now()) {
+      await invitationRef.update({ status: 'expired' })
+      return res.status(400).send('Invitation has expired')
+    }
+
+    const userRecord = await getAuth().getUser(userId)
+    if (userRecord.email !== invitation.email) {
+      return res.status(403).send('This invitation is for a different email address')
+    }
+
+    const projectDoc = await firestore.doc(projectPath).get()
+    if (!projectDoc.exists) return res.status(404).send('Project not found')
+
+    const members = projectDoc.data()?.members || {}
+    await firestore.doc(projectPath).update({
+      members: {
+        ...members,
+        [userId]: invitation.role,
+      },
+    })
+
+    await invitationRef.update({
+      status: 'accepted',
+      acceptedAt: Date.now(),
+      acceptedBy: userId,
+    })
+
+    return res.status(200).json({ accepted: true, orgId, projectId })
+  } catch (error) {
+    console.error('Failed to accept project invitation:', error)
+    return res.status(500).send('Failed to accept project invitation')
+  }
+}
+
+export const acceptProjectInvitation = withFirebaseAuth(acceptProjectInvitationBase)
+
 // POST /api/orgs/:orgId/invitations/:invitationId/accept
 const acceptInvitationBase = async (
   req: Request,

--- a/server/app/src/api/invitations.ts
+++ b/server/app/src/api/invitations.ts
@@ -83,7 +83,6 @@ const inviteMemberBase = async (
       })
     }
 
-    // TODO: Send invitation email via transactional email service (SendGrid/Resend)
     console.log(`Invitation created for ${email} to org ${orgId} - email sending not yet implemented`)
 
     return res.status(201).json({

--- a/server/app/src/api/invitations.ts
+++ b/server/app/src/api/invitations.ts
@@ -176,6 +176,16 @@ const inviteProjectMemberBase = async (
         acceptedBy: targetUserId,
       })
 
+      await firestore.collection(`users/${targetUserId}/notifications`).doc().set({
+        type: 'project_membership_added',
+        orgId,
+        projectId: `${orgId}/${projectId}`,
+        role,
+        createdAt: timestamp,
+        read: false,
+        message: `You were added to project ${orgId}/${projectId} as ${role}`,
+      })
+
       return res.status(201).json({
         invitationId: invitationRef.id,
         email,
@@ -184,13 +194,30 @@ const inviteProjectMemberBase = async (
       })
     }
 
-    console.log(`Project invitation created for ${email} in ${orgId}/${projectId} - email sending not yet implemented`)
+    const origin = req.headers.origin
+    const appUrl = (typeof origin === 'string' && origin) || process.env.NSTRUMENTA_APP_URL
+    if (!appUrl) {
+      return res.status(500).send('NSTRUMENTA_APP_URL or Origin header required for invitation links')
+    }
+
+    const acceptInviteUrl = new URL('/accept-invite', appUrl)
+    acceptInviteUrl.searchParams.set('orgId', orgId)
+    acceptInviteUrl.searchParams.set('projectId', projectId)
+    acceptInviteUrl.searchParams.set('invitationId', invitationRef.id)
+
+    await getAuth().generateSignInWithEmailLink(email, {
+      url: acceptInviteUrl.toString(),
+      handleCodeInApp: true,
+    })
+
+    console.log(`Project invitation created for ${email} in ${orgId}/${projectId} with Firebase sign-in link`)
 
     return res.status(201).json({
       invitationId: invitationRef.id,
       email,
       status: 'pending',
       existingUser: false,
+      delivery: 'firebase_signin_link',
     })
   } catch (error) {
     console.error('Failed to create project invitation:', error)

--- a/server/app/src/api/notifications.ts
+++ b/server/app/src/api/notifications.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express'
+import { firestore } from '../authentication/ServiceAccount'
+import { withFirebaseAuth, FirebaseAuthResult } from '../authentication/firebaseAuth'
+
+// PATCH /api/notifications/:notificationId — mark as read
+const markNotificationReadBase = async (
+  req: Request,
+  res: Response,
+  args: { notificationId: string } & FirebaseAuthResult,
+) => {
+  const { authenticated, userId, notificationId } = args
+  if (!authenticated || !userId) return res.status(401).send('Authentication required')
+
+  try {
+    const ref = firestore.doc(`users/${userId}/notifications/${notificationId}`)
+    const doc = await ref.get()
+    if (!doc.exists) return res.status(404).send('Notification not found')
+
+    await ref.update({ read: true })
+    return res.status(200).json({ notificationId, read: true })
+  } catch (error) {
+    console.error('Failed to mark notification read:', error)
+    return res.status(500).send('Failed to mark notification read')
+  }
+}
+
+export const markNotificationRead = withFirebaseAuth(markNotificationReadBase)
+
+// DELETE /api/notifications/:notificationId — dismiss notification
+const deleteNotificationBase = async (
+  req: Request,
+  res: Response,
+  args: { notificationId: string } & FirebaseAuthResult,
+) => {
+  const { authenticated, userId, notificationId } = args
+  if (!authenticated || !userId) return res.status(401).send('Authentication required')
+
+  try {
+    const ref = firestore.doc(`users/${userId}/notifications/${notificationId}`)
+    const doc = await ref.get()
+    if (!doc.exists) return res.status(404).send('Notification not found')
+
+    await ref.delete()
+    return res.status(200).json({ deleted: notificationId })
+  } catch (error) {
+    console.error('Failed to delete notification:', error)
+    return res.status(500).send('Failed to delete notification')
+  }
+}
+
+export const deleteNotification = withFirebaseAuth(deleteNotificationBase)

--- a/server/app/src/api/projectMembers.ts
+++ b/server/app/src/api/projectMembers.ts
@@ -1,0 +1,110 @@
+import { Request, Response } from 'express'
+import { firestore } from '../authentication/ServiceAccount'
+import { withFirebaseAuth, FirebaseAuthResult } from '../authentication/firebaseAuth'
+
+type ProjectMemberRole = 'owner' | 'admin' | 'viewer'
+
+function isProjectMemberRole(value: string): value is ProjectMemberRole {
+  return value === 'owner' || value === 'admin' || value === 'viewer'
+}
+
+function countOwners(members: Record<string, ProjectMemberRole>): number {
+  return Object.values(members).filter((role) => role === 'owner').length
+}
+
+// PATCH /api/orgs/:orgId/projects/:projectId/members/:memberId
+const updateProjectMemberRoleBase = async (
+  req: Request,
+  res: Response,
+  args: { orgId: string; projectId: string; memberId: string; role: string } & FirebaseAuthResult,
+) => {
+  const { authenticated, userId, orgId, projectId, memberId, role } = args
+  if (!authenticated || !userId) return res.status(401).send('Authentication required')
+  if (!isProjectMemberRole(role)) {
+    return res.status(400).send('role must be one of: owner, admin, viewer')
+  }
+
+  const projectPath = `organizations/${orgId}/projects/${projectId}`
+
+  try {
+    const projectDoc = await firestore.doc(projectPath).get()
+    if (!projectDoc.exists) return res.status(404).send('Project not found')
+
+    const members = (projectDoc.data()?.members || {}) as Record<string, ProjectMemberRole>
+    const callerRole = members[userId]
+    if (callerRole !== 'owner' && callerRole !== 'admin') {
+      return res.status(403).send('Only project owners and admins can manage members')
+    }
+
+    const targetRole = members[memberId]
+    if (!targetRole) return res.status(404).send('Project member not found')
+
+    if (callerRole === 'admin' && (targetRole === 'owner' || role === 'owner')) {
+      return res.status(403).send('Project admins cannot modify owner roles')
+    }
+
+    if (targetRole === 'owner' && role !== 'owner' && countOwners(members) <= 1) {
+      return res.status(400).send('Cannot remove the last project owner')
+    }
+
+    const updatedMembers = {
+      ...members,
+      [memberId]: role,
+    }
+
+    await firestore.doc(projectPath).update({ members: updatedMembers })
+
+    return res.status(200).json({ memberId, role })
+  } catch (error) {
+    console.error('Failed to update project member role:', error)
+    return res.status(500).send('Failed to update project member role')
+  }
+}
+
+export const updateProjectMemberRole = withFirebaseAuth(updateProjectMemberRoleBase)
+
+// DELETE /api/orgs/:orgId/projects/:projectId/members/:memberId
+const removeProjectMemberBase = async (
+  req: Request,
+  res: Response,
+  args: { orgId: string; projectId: string; memberId: string } & FirebaseAuthResult,
+) => {
+  const { authenticated, userId, orgId, projectId, memberId } = args
+  if (!authenticated || !userId) return res.status(401).send('Authentication required')
+
+  const projectPath = `organizations/${orgId}/projects/${projectId}`
+
+  try {
+    const projectDoc = await firestore.doc(projectPath).get()
+    if (!projectDoc.exists) return res.status(404).send('Project not found')
+
+    const members = (projectDoc.data()?.members || {}) as Record<string, ProjectMemberRole>
+    const callerRole = members[userId]
+    if (callerRole !== 'owner' && callerRole !== 'admin') {
+      return res.status(403).send('Only project owners and admins can manage members')
+    }
+
+    const targetRole = members[memberId]
+    if (!targetRole) return res.status(404).send('Project member not found')
+
+    if (callerRole === 'admin' && targetRole === 'owner') {
+      return res.status(403).send('Project admins cannot remove project owners')
+    }
+
+    if (targetRole === 'owner' && countOwners(members) <= 1) {
+      return res.status(400).send('Cannot remove the last project owner')
+    }
+
+    const updatedMembers = { ...members }
+    delete updatedMembers[memberId]
+
+    await firestore.doc(projectPath).update({ members: updatedMembers })
+
+    return res.status(200).json({ removed: memberId })
+  } catch (error) {
+    console.error('Failed to remove project member:', error)
+    return res.status(500).send('Failed to remove project member')
+  }
+}
+
+export const removeProjectMember = withFirebaseAuth(removeProjectMemberBase)

--- a/server/app/src/api/projectMembers.ts
+++ b/server/app/src/api/projectMembers.ts
@@ -1,6 +1,48 @@
 import { Request, Response } from 'express'
+import { getAuth } from 'firebase-admin/auth'
 import { firestore } from '../authentication/ServiceAccount'
 import { withFirebaseAuth, FirebaseAuthResult } from '../authentication/firebaseAuth'
+
+// GET /api/orgs/:orgId/projects/:projectId/members
+const listProjectMembersBase = async (
+  req: Request,
+  res: Response,
+  args: { orgId: string; projectId: string } & FirebaseAuthResult,
+) => {
+  const { authenticated, userId, orgId, projectId } = args
+  if (!authenticated || !userId) return res.status(401).send('Authentication required')
+
+  const projectPath = `organizations/${orgId}/projects/${projectId}`
+
+  try {
+    const projectDoc = await firestore.doc(projectPath).get()
+    if (!projectDoc.exists) return res.status(404).send('Project not found')
+
+    const members = (projectDoc.data()?.members || {}) as Record<string, ProjectMemberRole>
+    const callerRole = members[userId]
+    if (!callerRole) return res.status(403).send('Not a project member')
+
+    const memberIds = Object.keys(members)
+    const userRecords = await getAuth().getUsers(memberIds.map(uid => ({ uid })))
+
+    const result = memberIds.map(uid => {
+      const user = userRecords.users.find(u => u.uid === uid)
+      return {
+        memberId: uid,
+        email: user?.email ?? '',
+        displayName: user?.displayName ?? '',
+        role: members[uid],
+      }
+    })
+
+    return res.status(200).json(result)
+  } catch (error) {
+    console.error('Failed to list project members:', error)
+    return res.status(500).send('Failed to list project members')
+  }
+}
+
+export const listProjectMembers = withFirebaseAuth(listProjectMembersBase)
 
 type ProjectMemberRole = 'owner' | 'admin' | 'viewer'
 

--- a/server/app/src/authentication/projectAuth.ts
+++ b/server/app/src/authentication/projectAuth.ts
@@ -1,0 +1,77 @@
+import { Request, Response } from 'express'
+import { auth } from './index'
+import { firebaseAuth } from './firebaseAuth'
+import { firestore } from './ServiceAccount'
+import { parseOrgProject } from '../shared/utils'
+
+export type ProjectAuthResult =
+  | { authenticated: true; type: 'api-key'; projectId: string; apiKey: string; userId?: never }
+  | { authenticated: true; type: 'user'; projectId: string; userId: string; apiKey?: never }
+
+export function withProjectAuth<T>(
+  fn: (req: Request, res: Response, args: T & ProjectAuthResult) => Promise<unknown>,
+): (req: Request, res: Response) => Promise<unknown> {
+  return async function wrapped(req, res) {
+    // CORS headers
+    res.set('Access-Control-Allow-Origin', '*')
+    if (req.method === 'OPTIONS') {
+      res.set('Access-Control-Allow-Methods', '*')
+      res.set('Access-Control-Allow-Headers', '*')
+      res.set('Access-Control-Max-Age', '3600')
+      return res.status(204).send('')
+    }
+
+    // 1. Try API Key Auth
+    const apiAuth = await auth(req, res)
+    if (apiAuth.authenticated) {
+      // If a projectId is explicitly specified in the request, ensure it matches the API Key's scope
+      const requestedProjectId = req.params?.projectId || req.body?.projectId || req.query?.projectId
+      if (requestedProjectId && requestedProjectId !== apiAuth.projectId) {
+        return res.status(403).json({ error: 'API key is not valid for the requested project' })
+      }
+      
+      const payload = (req.body || {}) as T
+      return fn(req, res, { 
+        ...payload, 
+        authenticated: true, 
+        type: 'api-key', 
+        projectId: apiAuth.projectId, 
+        apiKey: apiAuth.apiKey 
+      })
+    }
+
+    // 2. Try Firebase User Auth
+    const userAuth = await firebaseAuth(req, res)
+    if (userAuth.authenticated) {
+      // When using user tokens, the request MUST specify which project they are accessing
+      const requestedProjectId = req.params?.projectId || req.body?.projectId || req.query?.projectId
+      if (!requestedProjectId) {
+         return res.status(400).json({ error: 'projectId is required in request when using user authentication' })
+      }
+      if (typeof requestedProjectId !== 'string') {
+         return res.status(400).json({ error: 'projectId must be a string' })
+      }
+
+      const { orgSlug, projectSlug } = parseOrgProject(requestedProjectId)
+      const memberDoc = await firestore
+        .doc(`organizations/${orgSlug}/projects/${projectSlug}/members/${userAuth.userId}`)
+        .get()
+      
+      if (!memberDoc.exists) {
+        return res.status(403).json({ error: 'Not a member of this project' })
+      }
+
+      const payload = (req.body || {}) as T
+      return fn(req, res, { 
+        ...payload, 
+        authenticated: true, 
+        type: 'user', 
+        projectId: requestedProjectId, 
+        userId: userAuth.userId 
+      })
+    }
+
+    // 3. Fallback
+    return res.status(401).json({ error: 'Valid Project API key or User token required.' })
+  }
+}

--- a/server/app/src/authentication/projectAuth.ts
+++ b/server/app/src/authentication/projectAuth.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import { auth } from './index'
 import { firebaseAuth } from './firebaseAuth'
 import { firestore } from './ServiceAccount'
-import { parseOrgProject } from '../shared/utils'
+import { orgProjectPath, parseOrgProject } from '../shared/utils'
 
 export type ProjectAuthResult =
   | { authenticated: true; type: 'api-key'; projectId: string; apiKey: string; userId?: never }
@@ -52,12 +52,18 @@ export function withProjectAuth<T>(
          return res.status(400).json({ error: 'projectId must be a string' })
       }
 
-      const { orgSlug, projectSlug } = parseOrgProject(requestedProjectId)
-      const memberDoc = await firestore
-        .doc(`organizations/${orgSlug}/projects/${projectSlug}/members/${userAuth.userId}`)
+      try {
+        parseOrgProject(requestedProjectId)
+      } catch {
+        return res.status(400).json({ error: 'projectId must be in a valid organization/project format' })
+      }
+
+      const projectDoc = await firestore
+        .doc(orgProjectPath(requestedProjectId))
         .get()
-      
-      if (!memberDoc.exists) {
+      const isProjectMember = !!projectDoc.data()?.members?.[userAuth.userId]
+
+      if (!projectDoc.exists || !isProjectMember) {
         return res.status(403).json({ error: 'Not a member of this project' })
       }
 

--- a/server/app/src/githubRoutes.ts
+++ b/server/app/src/githubRoutes.ts
@@ -1,11 +1,7 @@
 import crypto from 'crypto'
 import express from 'express'
-import rateLimit from 'express-rate-limit'
 import { firestore } from './authentication/ServiceAccount'
 import { withProjectAuth } from './authentication/projectAuth'
-
-const webhookRateLimit = rateLimit({ windowMs: 60_000, max: 120, standardHeaders: true, legacyHeaders: false })
-const linkRateLimit = rateLimit({ windowMs: 60_000, max: 20, standardHeaders: true, legacyHeaders: false })
 
 const GITHUB_APP_WEBHOOK_SECRET = process.env.GITHUB_APP_WEBHOOK_SECRET
 
@@ -85,7 +81,7 @@ async function handlePullRequest(action: string, installationId: string, repoFul
 
 export function registerGithubRoutes(app: express.Application) {
   // Must receive raw body for HMAC verification — register before global json middleware applies to this path
-  app.post('/api/github/webhook', webhookRateLimit, express.raw({ type: 'application/json' }), async (req, res) => {
+  app.post('/api/github/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
     const sig = req.headers['x-hub-signature-256'] as string | undefined
     if (!verifySignature(req.body as Buffer, sig)) {
       res.status(401).json({ error: 'invalid signature' })
@@ -136,7 +132,7 @@ export function registerGithubRoutes(app: express.Application) {
   })
 
   // Link an installation to a project (called from frontend after App install callback)
-  app.post('/api/github/installations/link', linkRateLimit, express.json(), withProjectAuth(async (req, res, args) => {
+  app.post('/api/github/installations/link', express.json(), withProjectAuth(async (req, res, args) => {
     const { installationId: rawInstallationId, projectId } = req.body
     if (!rawInstallationId || !projectId) {
       res.status(400).json({ error: 'installationId and projectId are required' })

--- a/server/app/src/githubRoutes.ts
+++ b/server/app/src/githubRoutes.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import express from 'express'
 import rateLimit from 'express-rate-limit'
 import { firestore } from './authentication/ServiceAccount'
+import { withProjectAuth } from './authentication/projectAuth'
 
 const webhookRateLimit = rateLimit({ windowMs: 60_000, max: 120, standardHeaders: true, legacyHeaders: false })
 const linkRateLimit = rateLimit({ windowMs: 60_000, max: 20, standardHeaders: true, legacyHeaders: false })
@@ -66,7 +67,6 @@ async function handlePush(installationId: string, repoFullName: string, ref: str
     return
   }
   console.log(`[github] push ${repoFullName}@${ref} (${headSha}) → project ${nstProjectId}`)
-  // TODO: enqueue publishModule + hostModule action for nstProjectId
 }
 
 async function handlePullRequest(action: string, installationId: string, repoFullName: string, prNumber: number, headSha: string) {
@@ -81,7 +81,6 @@ async function handlePullRequest(action: string, installationId: string, repoFul
     return
   }
   console.log(`[github] PR #${prNumber} ${repoFullName}@${headSha} → project ${nstProjectId}`)
-  // TODO: enqueue publishModule + hostModule, then post preview URL as PR comment
 }
 
 export function registerGithubRoutes(app: express.Application) {
@@ -137,13 +136,13 @@ export function registerGithubRoutes(app: express.Application) {
   })
 
   // Link an installation to a project (called from frontend after App install callback)
-  app.post('/api/github/installations/link', linkRateLimit, express.json(), async (req, res) => {
+  app.post('/api/github/installations/link', linkRateLimit, express.json(), withProjectAuth(async (req, res, args) => {
     const { installationId, projectId } = req.body
     if (!installationId || !projectId) {
       res.status(400).json({ error: 'installationId and projectId are required' })
       return
     }
-    // TODO: verify the authenticated user is a member of projectId before writing
+
     const docRef = firestore.doc(`githubInstallations/${installationId}`)
     const doc = await docRef.get()
     if (!doc.exists) {
@@ -158,5 +157,5 @@ export function registerGithubRoutes(app: express.Application) {
     await docRef.set({ linkedProjects, updatedAt: Date.now() }, { merge: true })
     console.log(`[github] installation ${installationId} linked to project ${projectId}`)
     res.status(200).json({ ok: true, linkedRepos: repoFullNames })
-  })
+  }))
 }

--- a/server/app/src/githubRoutes.ts
+++ b/server/app/src/githubRoutes.ts
@@ -137,9 +137,14 @@ export function registerGithubRoutes(app: express.Application) {
 
   // Link an installation to a project (called from frontend after App install callback)
   app.post('/api/github/installations/link', linkRateLimit, express.json(), withProjectAuth(async (req, res, args) => {
-    const { installationId, projectId } = req.body
-    if (!installationId || !projectId) {
+    const { installationId: rawInstallationId, projectId } = req.body
+    if (!rawInstallationId || !projectId) {
       res.status(400).json({ error: 'installationId and projectId are required' })
+      return
+    }
+    const installationId = String(rawInstallationId)
+    if (installationId.includes('/')) {
+      res.status(400).json({ error: 'invalid installationId' })
       return
     }
 

--- a/server/app/src/index.ts
+++ b/server/app/src/index.ts
@@ -18,6 +18,7 @@ import { registerOrgRoutes } from './orgRoutes'
 import { registerUserRoutes } from './userRoutes'
 import { registerAdminRoutes } from './adminRoutes'
 import { registerGithubRoutes } from './githubRoutes'
+import { markNotificationRead, deleteNotification } from './api/notifications'
 
 const version = require('../package.json').version
 
@@ -59,6 +60,15 @@ registerOrgRoutes(app)
 registerUserRoutes(app)
 registerAdminRoutes(app)
 registerGithubRoutes(app)
+
+app.patch('/api/notifications/:notificationId', (req, res) => {
+  req.body = { ...req.body, ...req.params }
+  markNotificationRead(req, res)
+})
+app.delete('/api/notifications/:notificationId', (req, res) => {
+  req.body = { ...req.body, ...req.params }
+  deleteNotification(req, res)
+})
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok', version, buildSha: imageVersionTag })

--- a/server/app/src/index.ts
+++ b/server/app/src/index.ts
@@ -54,7 +54,10 @@ const mcpLimiter = rateLimit({
   legacyHeaders: false,
 })
 
-app.use('/api/', apiLimiter)
+app.use('/api/', (req, res, next) => {
+  if (req.path === '/github/webhook') return next()
+  return apiLimiter(req, res, next)
+})
 
 // API routes first (before static files to prevent shadowing)
 registerOAuthRoutes(app)

--- a/server/app/src/index.ts
+++ b/server/app/src/index.ts
@@ -61,11 +61,11 @@ registerUserRoutes(app)
 registerAdminRoutes(app)
 registerGithubRoutes(app)
 
-app.patch('/api/notifications/:notificationId', (req, res) => {
+app.patch('/api/notifications/:notificationId', apiLimiter, (req, res) => {
   req.body = { ...req.body, ...req.params }
   markNotificationRead(req, res)
 })
-app.delete('/api/notifications/:notificationId', (req, res) => {
+app.delete('/api/notifications/:notificationId', apiLimiter, (req, res) => {
   req.body = { ...req.body, ...req.params }
   deleteNotification(req, res)
 })

--- a/server/app/src/index.ts
+++ b/server/app/src/index.ts
@@ -54,6 +54,8 @@ const mcpLimiter = rateLimit({
   legacyHeaders: false,
 })
 
+app.use('/api/', apiLimiter)
+
 // API routes first (before static files to prevent shadowing)
 registerOAuthRoutes(app)
 registerOrgRoutes(app)
@@ -61,11 +63,11 @@ registerUserRoutes(app)
 registerAdminRoutes(app)
 registerGithubRoutes(app)
 
-app.patch('/api/notifications/:notificationId', apiLimiter, (req, res) => {
+app.patch('/api/notifications/:notificationId', (req, res) => {
   req.body = { ...req.body, ...req.params }
   markNotificationRead(req, res)
 })
-app.delete('/api/notifications/:notificationId', apiLimiter, (req, res) => {
+app.delete('/api/notifications/:notificationId', (req, res) => {
   req.body = { ...req.body, ...req.params }
   deleteNotification(req, res)
 })

--- a/server/app/src/orgRoutes.ts
+++ b/server/app/src/orgRoutes.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import rateLimit from 'express-rate-limit'
 import { createOrg, getOrg, listOrgMembers, removeOrgMember, listUserOrgs } from './api/organizations'
 import { inviteMember, acceptInvitation, listInvitations, revokeInvitation, inviteProjectMember, acceptProjectInvitation } from './api/invitations'
+import { updateProjectMemberRole, removeProjectMember } from './api/projectMembers'
 import { getBilling, getUsage } from './api/billing'
 
 const orgLimiter = rateLimit({
@@ -28,6 +29,8 @@ export function registerOrgRoutes(app: express.Application) {
   router.delete('/:orgId/members/:memberId', mergeParams, removeOrgMember)
   router.post('/:orgId/projects/:projectId/invitations', mergeParams, inviteProjectMember)
   router.post('/:orgId/projects/:projectId/invitations/:invitationId/accept', mergeParams, acceptProjectInvitation)
+  router.patch('/:orgId/projects/:projectId/members/:memberId', mergeParams, updateProjectMemberRole)
+  router.delete('/:orgId/projects/:projectId/members/:memberId', mergeParams, removeProjectMember)
 
   router.post('/:orgId/invitations', mergeParams, inviteMember)
   router.get('/:orgId/invitations', mergeParams, listInvitations)

--- a/server/app/src/orgRoutes.ts
+++ b/server/app/src/orgRoutes.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import rateLimit from 'express-rate-limit'
 import { createOrg, getOrg, listOrgMembers, removeOrgMember, listUserOrgs } from './api/organizations'
-import { inviteMember, acceptInvitation, listInvitations, revokeInvitation } from './api/invitations'
+import { inviteMember, acceptInvitation, listInvitations, revokeInvitation, inviteProjectMember, acceptProjectInvitation } from './api/invitations'
 import { getBilling, getUsage } from './api/billing'
 
 const orgLimiter = rateLimit({
@@ -26,6 +26,8 @@ export function registerOrgRoutes(app: express.Application) {
 
   router.get('/:orgId/members', mergeParams, listOrgMembers)
   router.delete('/:orgId/members/:memberId', mergeParams, removeOrgMember)
+  router.post('/:orgId/projects/:projectId/invitations', mergeParams, inviteProjectMember)
+  router.post('/:orgId/projects/:projectId/invitations/:invitationId/accept', mergeParams, acceptProjectInvitation)
 
   router.post('/:orgId/invitations', mergeParams, inviteMember)
   router.get('/:orgId/invitations', mergeParams, listInvitations)

--- a/server/app/src/orgRoutes.ts
+++ b/server/app/src/orgRoutes.ts
@@ -1,16 +1,8 @@
 import express from 'express'
-import rateLimit from 'express-rate-limit'
 import { createOrg, getOrg, listOrgMembers, removeOrgMember, listUserOrgs } from './api/organizations'
 import { inviteMember, acceptInvitation, listInvitations, revokeInvitation, inviteProjectMember, acceptProjectInvitation } from './api/invitations'
 import { listProjectMembers, updateProjectMemberRole, removeProjectMember } from './api/projectMembers'
 import { getBilling, getUsage } from './api/billing'
-
-const orgLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-})
 
 function mergeParams(req: express.Request, _res: express.Response, next: express.NextFunction) {
   req.body = { ...req.body, ...req.params }
@@ -19,7 +11,6 @@ function mergeParams(req: express.Request, _res: express.Response, next: express
 
 export function registerOrgRoutes(app: express.Application) {
   const router = express.Router()
-  router.use(orgLimiter)
 
   router.post('/', createOrg)
   router.get('/', listUserOrgs)

--- a/server/app/src/orgRoutes.ts
+++ b/server/app/src/orgRoutes.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import rateLimit from 'express-rate-limit'
 import { createOrg, getOrg, listOrgMembers, removeOrgMember, listUserOrgs } from './api/organizations'
 import { inviteMember, acceptInvitation, listInvitations, revokeInvitation, inviteProjectMember, acceptProjectInvitation } from './api/invitations'
-import { updateProjectMemberRole, removeProjectMember } from './api/projectMembers'
+import { listProjectMembers, updateProjectMemberRole, removeProjectMember } from './api/projectMembers'
 import { getBilling, getUsage } from './api/billing'
 
 const orgLimiter = rateLimit({
@@ -29,6 +29,7 @@ export function registerOrgRoutes(app: express.Application) {
   router.delete('/:orgId/members/:memberId', mergeParams, removeOrgMember)
   router.post('/:orgId/projects/:projectId/invitations', mergeParams, inviteProjectMember)
   router.post('/:orgId/projects/:projectId/invitations/:invitationId/accept', mergeParams, acceptProjectInvitation)
+  router.get('/:orgId/projects/:projectId/members', mergeParams, listProjectMembers)
   router.patch('/:orgId/projects/:projectId/members/:memberId', mergeParams, updateProjectMemberRole)
   router.delete('/:orgId/projects/:projectId/members/:memberId', mergeParams, removeProjectMember)
 

--- a/server/app/src/services/firestoreArchive.ts
+++ b/server/app/src/services/firestoreArchive.ts
@@ -147,7 +147,7 @@ export function createArchiveService({
         console.log('archive is', project)
         console.log('archive succeeded :O')
 
-        return firestore.doc(`projects/${projectId}`)
+        return firestore.doc(projectPath)
       } catch (err) {
         await firestore
           .doc(actionPath)

--- a/server/app/src/services/firestoreArchive.ts
+++ b/server/app/src/services/firestoreArchive.ts
@@ -139,7 +139,6 @@ export function createArchiveService({
           .doc(timestamp.toString())
           .set({ archive: JSON.stringify(project), createdAt: timestamp })
 
-        // TODO: this should be managed by the listener which spawned this service action
         console.log(`set action ${actionPath} to complete`)
         await firestore
           .doc(actionPath)
@@ -148,8 +147,7 @@ export function createArchiveService({
         console.log('archive is', project)
         console.log('archive succeeded :O')
 
-        // TODO: Create archive metadata
-        return firestore.doc(`projects/${{ projectId }}`)
+        return firestore.doc(`projects/${projectId}`)
       } catch (err) {
         await firestore
           .doc(actionPath)
@@ -210,10 +208,6 @@ export function createArchiveService({
             originalPath,
           })
 
-          // TODO: sanitize the data;
-          // here's pme prob w/storing the archives within the project
-          // this cleaning step should already be taken care of when archive is created
-          // but we'll just make sure here
           if (!!data.archive) {
             console.log(`data is an archive`)
             return

--- a/terraform/firestore.rules
+++ b/terraform/firestore.rules
@@ -11,6 +11,11 @@ service cloud.firestore {
     match /users/{user} {
       allow read: if request.auth.uid == user;
       allow write: if false;
+
+      match /notifications/{notificationId} {
+        allow read: if request.auth.uid == user;
+        allow write: if false;
+      }
     }
 
     // Organizations: all writes go through server API (Admin SDK bypasses rules)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -143,6 +143,7 @@ resource "google_identity_platform_config" "auth" {
   sign_in {
     email {
       enabled = true
+      password_required = false
     }
 
     phone_number {


### PR DESCRIPTION
## Summary
- add a unified project auth wrapper that accepts either API keys or Firebase user tokens
- enforce project membership checks before linking GitHub installations to projects
- fix the archive service project document path bug
- remove stale TODO comments touched in the affected flow

## Validation
- npm run build && npm test in server/app
- integration-tests e2e suite passed locally