### PR TITLE
fix: bypass express.json for github webhook, refactor frontend link flow

### DIFF
--- a/frontend/src/app/pages/github-installed/github-installed.component.ts
+++ b/frontend/src/app/pages/github-installed/github-installed.component.ts
@@ -1,7 +1,5 @@
-import { Component, computed, effect, inject, signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, signal, OnInit } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { map } from 'rxjs';
 import { MatButton } from '@angular/material/button';
 import { ApiService } from 'src/app/services/api.service';
 
@@ -11,40 +9,15 @@ import { ApiService } from 'src/app/services/api.service';
   styleUrls: ['./github-installed.component.scss'],
   imports: [MatButton, RouterLink],
 })
-export class GithubInstalledComponent {
+export class GithubInstalledComponent implements OnInit {
   private route = inject(ActivatedRoute)
   private apiService = inject(ApiService)
-
-  readonly installationId = toSignal(
-    this.route.queryParamMap.pipe(map((params) => params.get('installation_id') ?? '')),
-    { initialValue: this.route.snapshot.queryParamMap.get('installation_id') ?? '' },
-  )
-  readonly state = toSignal(
-    this.route.queryParamMap.pipe(map((params) => params.get('state') ?? '')),
-    { initialValue: this.route.snapshot.queryParamMap.get('state') ?? '' },
-  )
-  readonly setupAction = toSignal(
-    this.route.queryParamMap.pipe(map((params) => params.get('setup_action') ?? '')),
-    { initialValue: this.route.snapshot.queryParamMap.get('setup_action') ?? '' },
-  )
 
   readonly status = signal<'linking' | 'success' | 'error'>('linking')
   readonly message = signal('Connecting GitHub installation...')
   readonly linkedRepos = signal<string[]>([])
-  readonly attempted = signal(false)
-  readonly parsedState = computed(() => {
-    const state = this.state()
-    const separatorIndex = state.lastIndexOf(':')
-    if (separatorIndex <= 0 || separatorIndex === state.length - 1) {
-      return null
-    }
-
-    return {
-      projectId: state.slice(0, separatorIndex),
-      stateToken: state.slice(separatorIndex + 1),
-    }
-  })
-  readonly projectId = computed(() => this.parsedState()?.projectId ?? '')
+  readonly projectId = signal('')
+  
   readonly returnRoute = computed(() => {
     const projectId = this.projectId()
     const [owner, project] = projectId.split('/')
@@ -52,35 +25,42 @@ export class GithubInstalledComponent {
     return ['/', owner, project, 'repositories']
   })
 
-  constructor() {
-    effect(() => {
-      const installationId = this.installationId()
-      const parsedState = this.parsedState()
-      const setupAction = this.setupAction()
+  ngOnInit() {
+    const installationId = this.route.snapshot.queryParamMap.get('installation_id') ?? ''
+    const state = this.route.snapshot.queryParamMap.get('state') ?? ''
+    const setupAction = this.route.snapshot.queryParamMap.get('setup_action') ?? ''
 
-      if (this.attempted()) return
-      this.attempted.set(true)
+    const separatorIndex = state.lastIndexOf(':')
+    if (separatorIndex <= 0 || separatorIndex === state.length - 1) {
+      this.status.set('error')
+      this.message.set('Missing or invalid installation callback state in the GitHub callback URL.')
+      return
+    }
 
-      if (!installationId || !parsedState?.projectId || !parsedState.stateToken) {
+    const projectId = state.slice(0, separatorIndex)
+    const stateToken = state.slice(separatorIndex + 1)
+    
+    this.projectId.set(projectId)
+
+    if (!installationId) {
+      this.status.set('error')
+      this.message.set('Missing installation_id in the GitHub callback URL.')
+      return
+    }
+
+    this.apiService.linkGithubInstallation(projectId, installationId, stateToken)
+      .then((response) => {
+        this.linkedRepos.set(response.linkedRepos)
+        this.status.set('success')
+        this.message.set(
+          setupAction === 'update'
+            ? 'GitHub installation updated and linked successfully.'
+            : 'GitHub installation linked successfully.',
+        )
+      })
+      .catch((error) => {
         this.status.set('error')
-        this.message.set('Missing or invalid installation callback state in the GitHub callback URL.')
-        return
-      }
-
-      this.apiService.linkGithubInstallation(parsedState.projectId, installationId, parsedState.stateToken)
-        .then((response) => {
-          this.linkedRepos.set(response.linkedRepos)
-          this.status.set('success')
-          this.message.set(
-            setupAction === 'update'
-              ? 'GitHub installation updated and linked successfully.'
-              : 'GitHub installation linked successfully.',
-          )
-        })
-        .catch((error) => {
-          this.status.set('error')
-          this.message.set(error instanceof Error ? error.message : 'Failed to link GitHub installation')
-        })
-    })
+        this.message.set(error instanceof Error ? error.message : 'Failed to link GitHub installation')
+      })
   }
 }

--- a/server/app/src/githubRoutes.ts
+++ b/server/app/src/githubRoutes.ts
@@ -340,6 +340,11 @@ async function handlePullRequest(action: string, installationId: string, repoFul
 
 export function registerGithubRoutes(app: express.Application) {
   app.post('/api/github/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
+    if (!Buffer.isBuffer(req.body)) {
+      console.error('[github webhook] Error: req.body is not a Buffer. Found:', typeof req.body);
+      res.status(500).json({ error: 'internal server error: invalid body format' });
+      return;
+    }
     const sig = req.headers['x-hub-signature-256'] as string | undefined
     if (!verifySignature(req.body as Buffer, sig)) {
       res.status(401).json({ error: 'invalid signature' })

--- a/server/app/src/index.ts
+++ b/server/app/src/index.ts
@@ -34,7 +34,7 @@ const port = process.env.API_PORT ?? 5999
 const app = express()
 app.set('trust proxy', 1)
 app.use((req, res, next) => {
-  if (req.path === '/api/github/webhook') return next()
+  if (req.path.replace(/\/$/, '') === '/api/github/webhook') return next()
   express.json()(req, res, next)
 })
 app.use(express.urlencoded({ extended: true }))


### PR DESCRIPTION
Fixes two issues preventing the GitHub App installation flow from completing:
1. Replaces global Express JSON middleware bypass mechanism to accommodate varying trailing slashes (so the GitHub Webhook HMAC payload remains a raw Buffer instead of an object).
2. Refactors the frontend GithubInstalledComponent from using effect with toSignal to ngOnInit with standard ActivatedRoute.snapshot data to prevent premature blocking of the API request on load.
